### PR TITLE
Switching to IAmazonCognitoIdentityProvider and passing the cancellationtoken to sdk calls

### DIFF
--- a/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoRoleStore.cs
+++ b/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoRoleStore.cs
@@ -26,10 +26,10 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
     public class CognitoRoleStore<TRole> : IRoleStore<TRole> where TRole : CognitoRole
     {
 
-        private AmazonCognitoIdentityProviderClient _cognitoClient;
+        private IAmazonCognitoIdentityProvider _cognitoClient;
         private CognitoUserPool _pool;
 
-        public CognitoRoleStore(AmazonCognitoIdentityProviderClient cognitoClient, CognitoUserPool pool)
+        public CognitoRoleStore(IAmazonCognitoIdentityProvider cognitoClient, CognitoUserPool pool)
         {
             _cognitoClient = cognitoClient ?? throw new ArgumentNullException(nameof(cognitoClient));
             _pool = pool ?? throw new ArgumentNullException(nameof(pool));

--- a/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoSigninManager.cs
@@ -125,8 +125,6 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
             }
             else if (user.SessionTokens != null && user.SessionTokens.IsValid())
             {
-                var claimsPrincipal = await _claimsFactory.CreateAsync(user).ConfigureAwait(false);
-                await _contextAccessor.HttpContext.SignInAsync(IdentityConstants.ApplicationScheme, claimsPrincipal).ConfigureAwait(false);
                 signinResult = SignInResult.Success;
             }
             else

--- a/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoUserStore/CognitoUserStore.IUserRoleStore.cs
+++ b/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoUserStore/CognitoUserStore.IUserRoleStore.cs
@@ -161,7 +161,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
                 UserAttributes = CreateAttributeList(newValues),
                 Username = user.Username,
                 UserPoolId = _pool.PoolID
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
 
             return IdentityResult.Success;
         }
@@ -210,7 +210,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
                 GroupName = roleName,
                 Username = user.Username,
                 UserPoolId = _pool.PoolID
-            });
+            }, cancellationToken);
         }
 
         /// <summary>
@@ -232,7 +232,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
                 GroupName = roleName,
                 Username = user.Username,
                 UserPoolId = _pool.PoolID
-            });
+            }, cancellationToken);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
             {
                 Username = user.Username,
                 UserPoolId = _pool.PoolID
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
 
             return response.Groups.Select(group => group.GroupName).ToList();
         }
@@ -294,7 +294,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
             {
                 GroupName = roleName,
                 UserPoolId = _pool.PoolID
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
 
             return response.Users.Select(user => _pool.GetUser(user.Username, user.UserStatus,
                 user.Attributes.ToDictionary(att => att.Name, att => att.Value))).ToList() as IList<TUser>;

--- a/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.AWSCognito/CognitoUserStore/CognitoUserStore.cs
@@ -26,11 +26,11 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
 {
     public partial class CognitoUserStore<TUser> : IUserCognitoStore<TUser> where TUser : CognitoUser
     {
-        private AmazonCognitoIdentityProviderClient _cognitoClient;
+        private IAmazonCognitoIdentityProvider _cognitoClient;
         private CognitoUserPool _pool;
         private IdentityErrorDescriber _errorDescribers;
 
-        public CognitoUserStore(AmazonCognitoIdentityProviderClient cognitoClient, CognitoUserPool pool, IdentityErrorDescriber errors)
+        public CognitoUserStore(IAmazonCognitoIdentityProvider cognitoClient, CognitoUserPool pool, IdentityErrorDescriber errors)
         {
             _cognitoClient = cognitoClient ?? throw new ArgumentNullException(nameof(cognitoClient));
             _pool = pool ?? throw new ArgumentNullException(nameof(pool));
@@ -114,7 +114,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
                 UserPoolId = _pool.PoolID
             };
 
-            await _cognitoClient.AdminResetUserPasswordAsync(request).ConfigureAwait(false);
+            await _cognitoClient.AdminResetUserPasswordAsync(request, cancellationToken).ConfigureAwait(false);
 
             return IdentityResult.Success;
         }
@@ -180,7 +180,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
             {
                 Username = user.Username,
                 UserPoolId = _pool.PoolID
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
             return IdentityResult.Success;
         }
 
@@ -208,7 +208,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
             {
                 AccessToken = user.SessionTokens.AccessToken,
                 AttributeName = attributeName
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
             return IdentityResult.Success;
         }
 
@@ -238,7 +238,7 @@ namespace Amazon.AspNetCore.Identity.AWSCognito
                 AccessToken = user.SessionTokens.AccessToken,
                 AttributeName = attributeName,
                 Code = code
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
             return IdentityResult.Success;
         }
 


### PR DESCRIPTION
Switching to IAmazonCognitoIdentityProvider and passing the cancellationToken to the sdk calls

*Issue #, if available:* DOTNET-3093

*Description of changes:*
Switching to IAmazonCognitoIdentityProvider and passing the cancellationToken to the sdk calls

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
