### PR TITLE
Enabling SMS 2FA by implementing IUserTwoFactorStore and SigninManager methods

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -221,7 +221,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public async Task<SignInResult> RespondToTwoFactorChallengeAsync(string code, bool isPersistent, bool rememberClient)
         {
             var twoFactorInfo = await RetrieveTwoFactorInfoAsync().ConfigureAwait(false);
-            if (twoFactorInfo == null || twoFactorInfo.UserId == null)
+            if (twoFactorInfo == null ||  string.IsNullOrWhiteSpace(twoFactorInfo.UserId))
             {
                 return SignInResult.Failed;
             }
@@ -234,7 +234,11 @@ namespace Amazon.AspNetCore.Identity.Cognito
             // Responding to the Cognito challenge.
             await _userManager.RespondToTwoFactorChallengeAsync(user, code, twoFactorInfo.CognitoAuthenticationWorkflowId).ConfigureAwait(false);
 
-            if (user.SessionTokens != null && user.SessionTokens.IsValid())
+            if (user.SessionTokens == null && !user.SessionTokens.IsValid())
+            {
+                return SignInResult.Failed;
+            }
+            else
             {
                 // Cleanup external cookie
                 if (twoFactorInfo.LoginProvider != null)
@@ -253,8 +257,6 @@ namespace Amazon.AspNetCore.Identity.Cognito
                 await SignInAsync(user, isPersistent, twoFactorInfo.LoginProvider).ConfigureAwait(false);
                 return SignInResult.Success;
             }
-
-            return SignInResult.Failed;
         }
 
         /// <summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -21,6 +21,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Generic;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace Amazon.AspNetCore.Identity.Cognito
@@ -31,10 +33,13 @@ namespace Amazon.AspNetCore.Identity.Cognito
         private readonly CognitoUserClaimsPrincipalFactory<TUser> _claimsFactory;
         private readonly IHttpContextAccessor _contextAccessor;
 
-        public CognitoSignInManager(UserManager<TUser> userManager, 
-            IHttpContextAccessor contextAccessor, 
-            IUserClaimsPrincipalFactory<TUser> claimsFactory, 
-            IOptions<IdentityOptions> optionsAccessor, 
+        private const string Cognito2FAAuthWorkflowKey = "Cognito2FAAuthWorkflowId";
+        private const string Cognito2FAProviderKey = "Amazon Cognito 2FA";
+
+        public CognitoSignInManager(UserManager<TUser> userManager,
+            IHttpContextAccessor contextAccessor,
+            IUserClaimsPrincipalFactory<TUser> claimsFactory,
+            IOptions<IdentityOptions> optionsAccessor,
             ILogger<SignInManager<TUser>> logger,
             IAuthenticationSchemeProvider schemes) : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes)
         {
@@ -70,7 +75,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public override async Task<SignInResult> PasswordSignInAsync(string userId, string password,
             bool isPersistent, bool lockoutOnFailure)
         {
-            if(lockoutOnFailure)
+            if (lockoutOnFailure)
             {
                 throw new NotSupportedException("Lockout is not enabled for the CognitoUserManager.");
             }
@@ -82,6 +87,36 @@ namespace Amazon.AspNetCore.Identity.Cognito
             }
 
             return await PasswordSignInAsync(user, password, isPersistent, lockoutOnFailure).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Attempts to sign in the specified <paramref name="user"/> and <paramref name="password"/> combination
+        /// as an asynchronous operation.
+        /// </summary>
+        /// <param name="user">The user to sign in.</param>
+        /// <param name="password">The password to attempt to sign in with.</param>
+        /// <param name="isPersistent">Flag indicating whether the sign-in cookie should persist after the browser is closed.</param>
+        /// <param name="lockoutOnFailure">Cognito does not handle account lock out. This parameter must be set to false, or a NotSupportedException will be thrown.</param>
+        /// <returns>The task object representing the asynchronous operation containing the <see name="SignInResult"/>
+        /// for the sign-in attempt.</returns>
+        public override async Task<SignInResult> PasswordSignInAsync(TUser user, string password,
+            bool isPersistent, bool lockoutOnFailure)
+        {
+            if (lockoutOnFailure)
+            {
+                throw new NotSupportedException("Lockout is not enabled for the CognitoUserManager.");
+            }
+
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            var attempt = await CheckPasswordSignInAsync(user, password, lockoutOnFailure).ConfigureAwait(false);
+            if (attempt.Succeeded)
+                await SignInAsync(user, isPersistent).ConfigureAwait(false);
+
+            return attempt;
         }
 
         /// <summary>
@@ -122,6 +157,16 @@ namespace Amazon.AspNetCore.Identity.Cognito
             else if (checkPasswordResult.ChallengeName == ChallengeNameType.SMS_MFA)
             {
                 signinResult = SignInResult.TwoFactorRequired;
+
+                var userPrincipal = new ClaimsPrincipal();
+                userPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>() {
+                    new Claim(ClaimTypes.Name, user.UserID),
+                    new Claim(Cognito2FAAuthWorkflowKey, checkPasswordResult.SessionID),
+                    new Claim(ClaimTypes.AuthenticationMethod, Cognito2FAProviderKey)
+                }));
+
+                // This signs in the user in the context of 2FA only. 
+                await Context.SignInAsync(IdentityConstants.TwoFactorUserIdScheme, userPrincipal).ConfigureAwait(false);
             }
             else if (user.SessionTokens != null && user.SessionTokens.IsValid())
             {
@@ -163,5 +208,102 @@ namespace Amazon.AspNetCore.Identity.Cognito
         {
             return _userManager.IsPasswordChangeRequiredAsync(user);
         }
+
+        /// <summary>
+        /// Validates the two factor sign in code and creates and signs in the user, as an asynchronous operation.
+        /// </summary>
+        /// <param name="code">The two factor authentication code to validate.</param>
+        /// <param name="isPersistent">Flag indicating whether the sign-in cookie should persist after the browser is closed.</param>
+        /// <param name="rememberClient">Flag indicating whether the current browser should be remember, suppressing all further 
+        /// two factor authentication prompts.</param>
+        /// <returns>The task object representing the asynchronous operation containing the <see name="SignInResult"/>
+        /// for the sign-in attempt.</returns>
+        public async Task<SignInResult> RespondToTwoFactorChallengeAsync(string code, bool isPersistent, bool rememberClient)
+        {
+            var twoFactorInfo = await RetrieveTwoFactorInfoAsync().ConfigureAwait(false);
+            if (twoFactorInfo == null || twoFactorInfo.UserId == null)
+            {
+                return SignInResult.Failed;
+            }
+            var user = await _userManager.FindByIdAsync(twoFactorInfo.UserId).ConfigureAwait(false);
+            if (user == null)
+            {
+                return SignInResult.Failed;
+            }
+
+            // Responding to the Cognito challenge.
+            await _userManager.RespondToTwoFactorChallengeAsync(user, code, twoFactorInfo.CognitoAuthenticationWorkflowId).ConfigureAwait(false);
+
+            if (user.SessionTokens != null && user.SessionTokens.IsValid())
+            {
+                // Cleanup external cookie
+                if (twoFactorInfo.LoginProvider != null)
+                {
+                    await Context.SignOutAsync(IdentityConstants.ExternalScheme).ConfigureAwait(false);
+                }
+                // Cleanup two factor user id cookie
+                await Context.SignOutAsync(IdentityConstants.TwoFactorUserIdScheme).ConfigureAwait(false);
+
+                if (rememberClient)
+                {
+                    await RememberTwoFactorClientAsync(user).ConfigureAwait(false);
+                }
+
+                // This creates the ClaimPrincipal and signs in the user in the IdentityConstants.ApplicationScheme
+                await SignInAsync(user, isPersistent, twoFactorInfo.LoginProvider).ConfigureAwait(false);
+                return SignInResult.Success;
+            }
+
+            return SignInResult.Failed;
+        }
+
+        /// <summary>
+        /// Gets the <typeparamref name="TUser"/> for the current two factor authentication login, as an asynchronous operation.
+        /// </summary>
+        /// <returns>The task object representing the asynchronous operation containing the <typeparamref name="TUser"/>
+        /// for the sign-in attempt.</returns>
+        public override async Task<TUser> GetTwoFactorAuthenticationUserAsync()
+        {
+            var info = await RetrieveTwoFactorInfoAsync().ConfigureAwait(false);
+            if (info == null)
+            {
+                return null;
+            }
+
+            return await UserManager.FindByIdAsync(info.UserId).ConfigureAwait(false);
+        }
+
+        #region 2FA
+
+        /// <summary>
+        /// Retrieves the information related to the authentication workflow.
+        /// </summary>
+        /// <returns></returns>
+        private async Task<TwoFactorAuthenticationInfo> RetrieveTwoFactorInfoAsync()
+        {
+            var result = await Context.AuthenticateAsync(IdentityConstants.TwoFactorUserIdScheme).ConfigureAwait(false);
+            if (result?.Principal != null)
+            {
+                return new TwoFactorAuthenticationInfo
+                {
+                    UserId = result.Principal.FindFirstValue(ClaimTypes.Name),
+                    LoginProvider = result.Principal.FindFirstValue(ClaimTypes.AuthenticationMethod),
+                    CognitoAuthenticationWorkflowId = result.Principal.FindFirstValue(Cognito2FAAuthWorkflowKey)
+                };
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Utility class to model information related to the ongoing authentication workflow.
+        /// </summary>
+        internal class TwoFactorAuthenticationInfo
+        {
+            public string UserId { get; set; }
+            public string LoginProvider { get; set; }
+            public string CognitoAuthenticationWorkflowId { get; set; }
+        }
+
+        #endregion
     }
 }

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -68,6 +68,40 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
+        /// Checks if the <param name="user"> can log in with the specified 2fa code challenge <paramref name="code"/>.
+        /// </summary>
+        /// <param name="user">The user try to log in with.</param>
+        /// <param name="code">The 2fa code to check</param>
+        /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
+        public Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId)
+        {
+            ThrowIfDisposed();
+            return _userStore.RespondToTwoFactorChallengeAsync(user, code, authWorkflowSessionId, CancellationToken);
+        }
+
+        /// <summary>
+        /// Sets a flag indicating whether the specified <paramref name="user"/> has two factor authentication enabled or not,
+        /// as an asynchronous operation.
+        /// </summary>
+        /// <param name="user">The user whose two factor authentication enabled status should be set.</param>
+        /// <param name="enabled">A flag indicating whether the specified <paramref name="user"/> has two factor authentication enabled.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, the <see cref="IdentityResult"/> of the operation
+        /// </returns>
+        public override async Task<IdentityResult> SetTwoFactorEnabledAsync(TUser user, bool enabled)
+        {
+            ThrowIfDisposed();
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            await _userStore.SetTwoFactorEnabledAsync(user, enabled, CancellationToken).ConfigureAwait(false);
+            return IdentityResult.Success;
+        }
+
+        /// <summary>
         /// Changes a user's password after confirming the specified <paramref name="currentPassword"/> is correct,
         /// as an asynchronous operation.
         /// </summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -64,6 +64,11 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public new Task<AuthFlowResponse> CheckPasswordAsync(TUser user, string password)
         {
             ThrowIfDisposed();
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
             return _userStore.StartValidatePasswordAsync(user, password, CancellationToken);
         }
 
@@ -77,6 +82,11 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId)
         {
             ThrowIfDisposed();
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
             return _userStore.RespondToTwoFactorChallengeAsync(user, code, authWorkflowSessionId, CancellationToken);
         }
 

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Amazon.AspNetCore.Identity.Cognito
+{
+    public partial class CognitoUserStore<TUser> : IUserTwoFactorStore<TUser> where TUser : CognitoUser
+    {
+        /// <summary>
+        /// Returns a flag indicating whether the specified <paramref name="user"/> has two factor authentication enabled or not,
+        /// as an asynchronous operation.
+        /// </summary>
+        /// <param name="user">The user whose two factor authentication enabled status should be retrieved.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing a flag indicating whether the specified 
+        /// <paramref name="user"/> has two factor authentication enabled or not.
+        /// </returns>
+        public async Task<bool> GetTwoFactorEnabledAsync(TUser user, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var request = new AdminGetUserRequest
+            {
+                Username = user.Username,
+                UserPoolId = _pool.PoolID
+            };
+            var userSettings = await _cognitoClient.AdminGetUserAsync(request, cancellationToken).ConfigureAwait(false);
+
+            return userSettings.MFAOptions.Count > 0;
+        }
+
+        /// <summary>
+        /// Sets a flag indicating whether the specified <paramref name="user"/> has two factor authentication enabled or not,
+        /// as an asynchronous operation.
+        /// </summary>
+        /// <param name="user">The user whose two factor authentication enabled status should be set.</param>
+        /// <param name="enabled">A flag indicating whether the specified <paramref name="user"/> has two factor authentication enabled.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public async Task SetTwoFactorEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var request = new AdminSetUserSettingsRequest
+            {
+                Username = user.Username,
+                UserPoolId = _pool.PoolID,
+                MFAOptions = new List<MFAOptionType>()
+                {
+                    new MFAOptionType()
+                    {
+                        AttributeName = CognitoAttributesConstants.PhoneNumber,
+                        DeliveryMedium = enabled ? DeliveryMediumType.SMS : null // Undocumented SDK behavior: sending null disables SMS 2FA
+                    }
+                }
+            };
+
+            await _cognitoClient.AdminSetUserSettingsAsync(request, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
@@ -17,6 +17,7 @@ using Amazon.CognitoIdentityProvider;
 using Amazon.CognitoIdentityProvider.Model;
 using Amazon.Extensions.CognitoAuthentication;
 using Microsoft.AspNetCore.Identity;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,11 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public async Task<bool> GetTwoFactorEnabledAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
             var request = new AdminGetUserRequest
             {
                 Username = user.Username,
@@ -57,6 +63,10 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public async Task SetTwoFactorEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
 
             var request = new AdminSetUserSettingsRequest
             {

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -68,6 +68,27 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
+        /// Checks if the <param name="user"> can log in with the specified 2fa code challenge <paramref name="code"/>.
+        /// </summary>
+        /// <param name="user">The user try to log in with.</param>
+        /// <param name="code">The 2fa code to check</param>
+        /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
+        public async Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            AuthFlowResponse context =
+                await user.RespondToSmsMfaAuthAsync(new RespondToSmsMfaRequest()
+                {
+                    SessionID = authWorkflowSessionId,
+                    MfaCode = code
+                }).ConfigureAwait(false);
+
+            return context;
+        }
+
+        /// <summary>
         /// Changes the password on the cognito account associated with the <paramref name="user"/>.
         /// </summary>
         /// <param name="user">The user to change the password for.</param>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
@@ -143,5 +143,13 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </returns>
         Task<IdentityResult> VerifyUserAttributeAsync(TUser user, string attributeName, string code, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Checks if the <param name="user"> can log in with the specified 2fa code challenge <paramref name="code"/>.
+        /// </summary>
+        /// <param name="user">The user try to log in with.</param>
+        /// <param name="code">The 2fa code to check</param>
+        /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
+        Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId, CancellationToken cancellationToken);
     }
 }


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3168

*Description of changes:* This change enables the SMS 2FA on Cognito authentication workflow:

- Respond to an SMS challenge
- Enable/Disable SMS 2FA for a user
- Retrieve 2FA Status for a user
- Signin workflow updated to work around the Cognito workflow (Need to respond to the challenge WITH the current auth session id)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
