### PR TITLE
Forgot password with token and FindByEmail() implementation

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -151,18 +151,20 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="user">The user whose password should be reset.</param>
         /// <param name="token">The password reset token to verify.</param>
-        /// <param name="newPassword">The new password to set if reset token verification fails.</param>
+        /// <param name="newPassword">The new password to set if reset token verification succeeds.</param>
         /// <returns>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
         public override Task<IdentityResult> ResetPasswordAsync(TUser user, string token, string newPassword)
         {
-            throw new NotSupportedException("This is not supported by Cognito. Use the ResetPasswordAsync(TUser user) overload instead.");
+            ThrowIfDisposed();
+
+            return _userStore.ChangePasswordWithTokenAsync(user, token, newPassword, CancellationToken);
         }
 
         /// <summary>
-        /// Resets the <paramref name="user"/>'s password and sends the new password to the user 
+        /// Resets the <paramref name="user"/>'s password and sends the confirmation token to the user 
         /// via email or sms depending on the user pool policy.
         /// </summary>
         /// <param name="user">The user whose password should be reset.</param>
@@ -178,7 +180,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return _userStore.ResetUserPasswordAsync(user, CancellationToken);
+            return _userStore.ResetPasswordAsync(user, CancellationToken);
         }
 
         /// <summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -112,6 +112,26 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
+        /// Resets the <paramref name="user"/>'s password to the specified <paramref name="newPassword"/> after
+        /// validating the given password reset <paramref name="token"/>.
+        /// </summary>
+        /// <param name="user">The user whose password should be reset.</param>
+        /// <param name="token">The password reset token to verify.</param>
+        /// <param name="newPassword">The new password to set if reset token verification succeeds.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
+        /// of the operation.
+        /// </returns>
+        public async Task<IdentityResult> ChangePasswordWithTokenAsync(TUser user, string token, string newPassword, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await _pool.ConfirmForgotPassword(user.Username, token, newPassword, cancellationToken).ConfigureAwait(false);
+
+            return IdentityResult.Success;
+        }
+
+        /// <summary>
         /// Checks if the password needs to be changed for the specified <paramref name="user"/>.
         /// </summary>
         /// <param name="user">The user to check if the password needs to be changed.</param>
@@ -124,12 +144,13 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
-        /// Resets the password for the specified <paramref name="user"/>.
+        /// Resets the <paramref name="user"/>'s password and sends the confirmation token to the user 
+        /// via email or sms depending on the user pool policy.
         /// </summary>
         /// <param name="user">The user to reset the password for.</param>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
-        public async Task<IdentityResult> ResetUserPasswordAsync(TUser user, CancellationToken cancellationToken)
+        public async Task<IdentityResult> ResetPasswordAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var request = new AdminResetUserPasswordRequest

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -147,7 +147,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
             }
             catch (AmazonCognitoIdentityProviderException e)
             {
-                return IdentityResult.Failed(_errorDescribers.CognitoServiceError("Failed to change Cognito User password", e.Message));
+                return IdentityResult.Failed(_errorDescribers.CognitoServiceError("Failed to change Cognito User password", e));
             }
         }
 

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
@@ -48,6 +48,19 @@ namespace Amazon.AspNetCore.Identity.Cognito
         Task<IdentityResult> ChangePasswordAsync(TUser user, string currentPassword, string newPassword, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Resets the <paramref name="user"/>'s password to the specified <paramref name="newPassword"/> after
+        /// validating the given password reset <paramref name="token"/>.
+        /// </summary>
+        /// <param name="user">The user whose password should be reset.</param>
+        /// <param name="token">The password reset token to verify.</param>
+        /// <param name="newPassword">The new password to set if reset token verification succeeds.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
+        /// of the operation.
+        /// </returns>
+        Task<IdentityResult> ChangePasswordWithTokenAsync(TUser user, string token, string newPassword, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Checks if the password needs to be changed for the specified <paramref name="user"/>.
         /// </summary>
         /// <param name="user">The user to check if the password needs to be changed.</param>
@@ -55,11 +68,12 @@ namespace Amazon.AspNetCore.Identity.Cognito
         Task<bool> IsPasswordChangeRequiredAsync(TUser user, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Resets the password for the specified <paramref name="user"/>.
+        /// Resets the <paramref name="user"/>'s password and sends the confirmation token to the user 
+        /// via email or sms depending on the user pool policy.
         /// </summary>
         /// <param name="user">The user to reset the password for.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a boolean set to true if the password was reset, false otherwise.</returns>
-        Task<IdentityResult> ResetUserPasswordAsync(TUser user, CancellationToken cancellationToken);
+        Task<IdentityResult> ResetPasswordAsync(TUser user, CancellationToken cancellationToken);
 
         /// <summary>
         /// Registers the specified <paramref name="user"/> in Cognito with the given password,

--- a/src/Amazon.AspNetCore.Identity.Cognito/Exceptions/CognitoIdentityErrorDescriber.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Exceptions/CognitoIdentityErrorDescriber.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Microsoft.AspNetCore.Identity;
+using System;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Exceptions
+{
+    /// <summary>
+    /// Service to enable Cognito specific errors for application facing identity errors.
+    /// </summary>
+    /// <remarks>
+    /// These errors are returned to controllers and are generally used as display messages to end users.
+    /// </remarks>
+    public class CognitoIdentityErrorDescriber : IdentityErrorDescriber
+    {
+        /// <summary>
+        /// Returns the <see cref="IdentityError"/> indicating a CognitoServiceError.
+        /// </summary>
+        /// <param name="failingOperationMessage">The message related to the operation that failed</param>
+        /// <param name="exceptionMessage">The exception message.</param>
+        /// <returns>The default <see cref="IdentityError"/>.</returns>
+        public IdentityError CognitoServiceError(string failingOperationMessage, string exceptionMessage)
+        {
+            return new IdentityError
+            {
+                Code = nameof(CognitoServiceError),
+                Description = String.Format("{0} : {1}", failingOperationMessage, exceptionMessage)
+            };
+        }
+    }
+}

--- a/src/Amazon.AspNetCore.Identity.Cognito/Exceptions/CognitoIdentityErrorDescriber.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Exceptions/CognitoIdentityErrorDescriber.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.CognitoIdentityProvider;
 using Microsoft.AspNetCore.Identity;
 using System;
 
@@ -30,14 +31,14 @@ namespace Amazon.AspNetCore.Identity.Cognito.Exceptions
         /// Returns the <see cref="IdentityError"/> indicating a CognitoServiceError.
         /// </summary>
         /// <param name="failingOperationMessage">The message related to the operation that failed</param>
-        /// <param name="exceptionMessage">The exception message.</param>
+        /// <param name="exception">The exception</param>
         /// <returns>The default <see cref="IdentityError"/>.</returns>
-        public IdentityError CognitoServiceError(string failingOperationMessage, string exceptionMessage)
+        public IdentityError CognitoServiceError(string failingOperationMessage, AmazonCognitoIdentityProviderException exception)
         {
             return new IdentityError
             {
                 Code = nameof(CognitoServiceError),
-                Description = String.Format("{0} : {1}", failingOperationMessage, exceptionMessage)
+                Description = String.Format("{0} : {1}", failingOperationMessage, exception.Message)
             };
         }
     }

--- a/src/Amazon.AspNetCore.Identity.Cognito/Exceptions/CognitoServiceException.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Exceptions/CognitoServiceException.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Exceptions
+{
+    public class CognitoServiceException : Exception
+    {
+        private CognitoServiceException()
+        {
+        }
+
+        private CognitoServiceException(string message) : base(message) { }
+
+        /// <summary>
+        /// Constructs an instance of CognitoServiceException
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="innerException">The original exception.</param>
+        public CognitoServiceException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+    }
+}

--- a/src/Amazon.AspNetCore.Identity.Cognito/Extensions/CognitoServiceCollectionExtensions.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Extensions/CognitoServiceCollectionExtensions.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IRoleStore<CognitoRole>, CognitoRoleStore<CognitoRole>>();
             services.AddScoped<IUserClaimStore<TUser>, CognitoUserStore<TUser>>();
             services.AddScoped<IUserClaimsPrincipalFactory<TUser>, CognitoUserClaimsPrincipalFactory<TUser>>();
-            services.AddScoped<CognitoKeyNormalizer, CognitoKeyNormalizer>();
-            services.AddScoped<IdentityErrorDescriber, CognitoIdentityErrorDescriber>();
+            services.AddSingleton<CognitoKeyNormalizer, CognitoKeyNormalizer>();
+            services.AddSingleton<IdentityErrorDescriber, CognitoIdentityErrorDescriber>();
 
             services.AddHttpContextAccessor();
             return services;

--- a/src/Amazon.AspNetCore.Identity.Cognito/Extensions/CognitoServiceCollectionExtensions.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Extensions/CognitoServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddScoped<IUserClaimStore<TUser>, CognitoUserStore<TUser>>();
             services.AddScoped<IUserClaimsPrincipalFactory<TUser>, CognitoUserClaimsPrincipalFactory<TUser>>();
             services.AddScoped<CognitoKeyNormalizer, CognitoKeyNormalizer>();
+            services.AddScoped<IdentityErrorDescriber, CognitoIdentityErrorDescriber>();
 
             services.AddHttpContextAccessor();
             return services;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

My first implementation of 'Forgot password' feature was based on the reset password api call and missing the workflow to reset the password based on the token received by sms/email.

Here is the implementation.

Workflow in the ForgotPassword controller is:


```
var user = await _userManager.FindByEmailAsync(Input.Email).ConfigureAwait(false);

await _userManager.ResetPasswordAsync(user).ConfigureAwait(false);

var token = "123456"; //received by SMS

await _userManager.ResetPasswordAsync(user, token, "newPassword").ConfigureAwait(false);
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
