### PR TITLE
Adding unit tests for CognitoSigninManager and CognitoUserManager

### DIFF
--- a/Amazon.AspNetCore.Identity.Cognito.sln
+++ b/Amazon.AspNetCore.Identity.Cognito.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.AspNetCore.Identity.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amazon.Extensions.CognitoAuthentication", "..\aws-sdk-net-extensions-cognito\src\Amazon.Extensions.CognitoAuthentication\Amazon.Extensions.CognitoAuthentication.csproj", "{EEB5B65E-6838-4AB3-8065-ECF39FEB4073}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amazon.AspNetCore.Identity.Cognito.Test", "test\Amazon.AspNetCore.Identity.Cognito.Test\Amazon.AspNetCore.Identity.Cognito.Test.csproj", "{DA639864-EC7D-44A9-8946-781B11A15D6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{EEB5B65E-6838-4AB3-8065-ECF39FEB4073}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EEB5B65E-6838-4AB3-8065-ECF39FEB4073}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EEB5B65E-6838-4AB3-8065-ECF39FEB4073}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DA639864-EC7D-44A9-8946-781B11A15D6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DA639864-EC7D-44A9-8946-781B11A15D6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DA639864-EC7D-44A9-8946-781B11A15D6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DA639864-EC7D-44A9-8946-781B11A15D6F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -42,11 +42,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\aws-sdk-net-extensions-cognito\src\Amazon.Extensions.CognitoAuthentication\Amazon.Extensions.CognitoAuthentication.csproj" />
+    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" />
+    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NetCore.Analyzers" Version="2.6.2" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers" Version="2.6.2" />
+    <ProjectReference Include="..\..\..\aws-sdk-net-extensions-cognito\src\Amazon.Extensions.CognitoAuthentication\Amazon.Extensions.CognitoAuthentication.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoRoleStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoRoleStore.cs
@@ -40,7 +40,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="role">The role to create in the store.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the <see cref="IdentityResult"/> of the asynchronous query.</returns>
-        public async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (role == null)
@@ -65,7 +65,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="role">The role to delete from the store.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the <see cref="IdentityResult"/> of the asynchronous query.</returns>
-        public async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (role == null)
@@ -87,7 +87,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="roleName">The role name to look for.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the result of the look up.</returns>
-        public async Task<TRole> FindByNameAsync(string roleName, CancellationToken cancellationToken)
+        public virtual async Task<TRole> FindByNameAsync(string roleName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -107,7 +107,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="role">The role to update in the store.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the <see cref="IdentityResult"/> of the asynchronous query.</returns>
-        public async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (role == null)
@@ -132,7 +132,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="role">The role whose name should be returned.</param>
         /// <returns>A <see cref="Task{TResult}"/> that contains the name of the role.</returns>
-        public Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken)
+        public virtual Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken)
         {
             return Task.FromResult(role.Name);
         }

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -256,7 +256,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
             // Responding to the Cognito challenge.
             await _userManager.RespondToTwoFactorChallengeAsync(user, code, twoFactorInfo.CognitoAuthenticationWorkflowId).ConfigureAwait(false);
 
-            if (user.SessionTokens == null && !user.SessionTokens.IsValid())
+            if (user.SessionTokens == null || !user.SessionTokens.IsValid())
             {
                 return SignInResult.Failed;
             }

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -61,7 +61,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object
         /// if the specified <paramref name="password" /> matches the one store for the <paramref name="user"/>,
         /// otherwise null.</returns>
-        public new Task<AuthFlowResponse> CheckPasswordAsync(TUser user, string password)
+        public virtual Task<AuthFlowResponse> CheckPasswordAsync(TUser user, string password)
         {
             ThrowIfDisposed();
             if (user == null)
@@ -79,7 +79,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="code">The 2fa code to check</param>
         /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
-        public Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId)
+        public virtual Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId)
         {
             ThrowIfDisposed();
             if (user == null)
@@ -139,7 +139,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="user">The user to check if the password needs to be changed.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a boolean set to true if the password needs to be changed, false otherwise.</returns>
-        public Task<bool> IsPasswordChangeRequiredAsync(TUser user)
+        public virtual Task<bool> IsPasswordChangeRequiredAsync(TUser user)
         {
             ThrowIfDisposed();
             return _userStore.IsPasswordChangeRequiredAsync(user, CancellationToken);

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserClaimStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserClaimStore.cs
@@ -36,7 +36,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>
         /// A <see cref="Task{TResult}"/> that represents the result of the asynchronous query, a list of <see cref="Claim"/>s.
         /// </returns>
-        public async Task<IList<Claim>> GetClaimsAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IList<Claim>> GetClaimsAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)
@@ -67,7 +67,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="user">The user to add the claim to.</param>
         /// <param name="claims">The collection of <see cref="Claim"/>s to add.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public async Task AddClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        public virtual async Task AddClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)
@@ -118,7 +118,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="user">The user to remove the specified <paramref name="claims"/> from.</param>
         /// <param name="claims">A collection of <see cref="Claim"/>s to remove.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public async Task RemoveClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        public virtual async Task RemoveClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserEmailStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserEmailStore.cs
@@ -34,7 +34,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>
         /// The task object containing the results of the asynchronous lookup operation, the user if any associated with the specified normalized email address.
         /// </returns>
-        public async Task<TUser> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
+        public virtual async Task<TUser> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -61,14 +61,14 @@ namespace Amazon.AspNetCore.Identity.Cognito
             return null;
         }
 
-        public async Task<string> GetEmailAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<string> GetEmailAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             return await GetAttributeValueAsync(user, CognitoAttributesConstants.Email, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<bool> GetEmailConfirmedAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<bool> GetEmailConfirmedAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -80,7 +80,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
             throw new NotSupportedException("Cognito does not support normalized emails.");
         }
 
-        public Task SetEmailAsync(TUser user, string email, CancellationToken cancellationToken)
+        public virtual Task SetEmailAsync(TUser user, string email, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserPhoneNumberStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserPhoneNumberStore.cs
@@ -23,21 +23,21 @@ namespace Amazon.AspNetCore.Identity.Cognito
 {
     public partial class CognitoUserStore<TUser> : IUserPhoneNumberStore<TUser> where TUser : CognitoUser
     {
-        public async Task<string> GetPhoneNumberAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<string> GetPhoneNumberAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             return await GetAttributeValueAsync(user, CognitoAttributesConstants.PhoneNumber, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<bool> GetPhoneNumberConfirmedAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<bool> GetPhoneNumberConfirmedAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
             return String.Equals(await GetAttributeValueAsync(user, CognitoAttributesConstants.PhoneNumberVerified, cancellationToken).ConfigureAwait(false), "true", StringComparison.InvariantCultureIgnoreCase);
         }
 
-        public Task SetPhoneNumberAsync(TUser user, string phoneNumber, CancellationToken cancellationToken)
+        public virtual Task SetPhoneNumberAsync(TUser user, string phoneNumber, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserRoleStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserRoleStore.cs
@@ -38,7 +38,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the user matching the specified <paramref name="userId"/> if it exists.
         /// </returns>
-        public async Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken)
+        public virtual async Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             try
@@ -61,7 +61,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the userId belonging to the matching the specified <paramref name="userId"/>.
         /// </returns>
-        public Task<string> GetUserIdAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<string> GetUserIdAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(user.UserID);
@@ -75,7 +75,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the UserName belonging to the matching the specified <paramref name="userId"/>.
         /// </returns>
-        public Task<string> GetUserNameAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<string> GetUserNameAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(user.Username);
@@ -90,7 +90,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public Task<IdentityResult> CreateAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<IdentityResult> CreateAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -107,7 +107,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public async Task<IdentityResult> CreateAsync(TUser user, IDictionary<string, string> validationData, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> CreateAsync(TUser user, IDictionary<string, string> validationData, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             try
@@ -126,7 +126,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="user">The user to delete.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/> of the update operation.</returns>
-        public async Task<IdentityResult> DeleteAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> DeleteAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -154,7 +154,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the user matching the specified <paramref name="normalizedUserName"/> if it exists.
         /// </returns>
-        public Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
+        public virtual Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
         {
             return FindByIdAsync(normalizedUserName, cancellationToken);
         }
@@ -179,7 +179,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="user">The user to update attributes for.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/> of the update operation.</returns>
-        public async Task<IdentityResult> UpdateAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> UpdateAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)
@@ -241,7 +241,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="user">The user to add to the named role.</param>
         /// <param name="roleName">The name of the role to add the user to.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public Task AddToRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        public virtual Task AddToRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)
@@ -270,7 +270,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="user">The user to remove the named role from.</param>
         /// <param name="roleName">The name of the role to remove.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public Task RemoveFromRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        public virtual Task RemoveFromRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)
@@ -298,7 +298,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="user">The user whose role names to retrieve.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a list of role names.</returns>
-        public async Task<IList<string>> GetRolesAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IList<string>> GetRolesAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)
@@ -332,7 +332,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing a flag indicating whether the specified <paramref name="user"/> is
         /// a member of the named role.
         /// </returns>
-        public async Task<bool> IsInRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        public virtual async Task<bool> IsInRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)
@@ -351,7 +351,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing a list of users who are in the named role.
         /// </returns>
-        public async Task<IList<TUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken)
+        public virtual async Task<IList<TUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
@@ -36,7 +36,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing a flag indicating whether the specified 
         /// <paramref name="user"/> has two factor authentication enabled or not.
         /// </returns>
-        public async Task<bool> GetTwoFactorEnabledAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<bool> GetTwoFactorEnabledAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.IUserTwoFactorStore.cs
@@ -69,7 +69,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="user">The user whose two factor authentication enabled status should be set.</param>
         /// <param name="enabled">A flag indicating whether the specified <paramref name="user"/> has two factor authentication enabled.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public async Task SetTwoFactorEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
+        public virtual async Task SetTwoFactorEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (user == null)

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -57,7 +57,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="user">The user try to log in with.</param>
         /// <param name="password">The password supplied for validation.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
-        public async Task<AuthFlowResponse> StartValidatePasswordAsync(TUser user, string password, CancellationToken cancellationToken)
+        public virtual async Task<AuthFlowResponse> StartValidatePasswordAsync(TUser user, string password, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             try
@@ -85,7 +85,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="code">The 2fa code to check</param>
         /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
-        public async Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId, CancellationToken cancellationToken)
+        public virtual async Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -114,7 +114,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="newPassword">The new passord for the user.</param>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
-        public async Task<IdentityResult> ChangePasswordAsync(TUser user, string currentPassword, string newPassword, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> ChangePasswordAsync(TUser user, string currentPassword, string newPassword, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             try
@@ -146,7 +146,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public async Task<IdentityResult> ChangePasswordWithTokenAsync(TUser user, string token, string newPassword, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> ChangePasswordWithTokenAsync(TUser user, string token, string newPassword, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -180,7 +180,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="user">The user to reset the password for.</param>
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
-        public async Task<IdentityResult> ResetPasswordAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> ResetPasswordAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var request = new AdminResetUserPasswordRequest

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -166,7 +166,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// </summary>
         /// <param name="user">The user to check if the password needs to be changed.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a boolean set to true if the password needs to be changed, false otherwise.</returns>
-        public Task<bool> IsPasswordChangeRequiredAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<bool> IsPasswordChangeRequiredAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             bool IsPasswordChangeRequired = user.Status.Equals(UserStatusForceChangePassword, StringComparison.InvariantCulture) || user.Status.Equals(UserStatusResetRequired, StringComparison.InvariantCulture);
@@ -212,7 +212,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public async Task<IdentityResult> CreateAsync(TUser user, string password, IDictionary<string, string> validationData, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> CreateAsync(TUser user, string password, IDictionary<string, string> validationData, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -244,7 +244,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public async Task<IdentityResult> ConfirmSignUpAsync(TUser user, string confirmationCode, bool forcedAliasCreation, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> ConfirmSignUpAsync(TUser user, string confirmationCode, bool forcedAliasCreation, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -268,7 +268,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public async Task<IdentityResult> AdminConfirmSignUpAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> AdminConfirmSignUpAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -298,7 +298,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public async Task<IdentityResult> GetUserAttributeVerificationCodeAsync(TUser user, string attributeName, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> GetUserAttributeVerificationCodeAsync(TUser user, string attributeName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -334,7 +334,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
         /// of the operation.
         /// </returns>
-        public async Task<IdentityResult> VerifyUserAttributeAsync(TUser user, string attributeName, string code, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> VerifyUserAttributeAsync(TUser user, string attributeName, string code, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
@@ -28,7 +28,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
     /// Retrieving the user status or changing/reseting the password.
     /// </summary>
     /// <typeparam name="TUser">The type encapsulating a user.</typeparam>
-    interface IUserCognitoStore<TUser> : IDisposable where TUser : class
+    public interface IUserCognitoStore<TUser> : IDisposable where TUser : class
     {
         /// <summary>
         /// Checks if the <param name="user"> can log in with the specified password <paramref name="password"/>.

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/Amazon.AspNetCore.Identity.Cognito.Test.csproj
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/Amazon.AspNetCore.Identity.Cognito.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/Amazon.AspNetCore.Identity.Cognito.Test.csproj
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/Amazon.AspNetCore.Identity.Cognito.Test.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <ApplicationIcon />
+    <StartupObject />
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\aws-sdk-net-extensions-cognito\src\Amazon.Extensions.CognitoAuthentication\Amazon.Extensions.CognitoAuthentication.csproj" />
+    <ProjectReference Include="..\..\src\Amazon.AspNetCore.Identity.Cognito\Amazon.AspNetCore.Identity.Cognito.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
@@ -32,9 +32,9 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
         public CognitoSigninManagerTest() : base()
         {
-            userManagerMock = new Mock<CognitoUserManager<CognitoUser>>(storeMock.Object, null, null, null, null, null, null, null, null);
+            userManagerMock = new Mock<CognitoUserManager<CognitoUser>>(userStoreMock.Object, null, null, null, null, null, null, null, null);
             claimsFactoryMock = new Mock<CognitoUserClaimsPrincipalFactory<CognitoUser>>(userManagerMock.Object, optionsAccessorMock.Object);
-            signinManager = new CognitoSignInManager<CognitoUser>(userManagerMock.Object, contextAccessorMock.Object, claimsFactoryMock.Object, optionsAccessorMock.Object, loggerMock.Object, schemesMock.Object);
+            signinManager = new CognitoSignInManager<CognitoUser>(userManagerMock.Object, contextAccessorMock.Object, claimsFactoryMock.Object, optionsAccessorMock.Object, loggerSigninManagerMock.Object, schemesMock.Object);
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
             CognitoUser user = null;
             userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(user)).Verifiable();
             var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
-            Assert.Equal(output, signinResult);
+            Assert.Equal(signinResult, output);
             userManagerMock.Verify();
         }
         
@@ -62,7 +62,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
             var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
 
-            Assert.Equal(output, signinResult);
+            Assert.Equal(signinResult, output);
             userManagerMock.Verify();
         }
 
@@ -90,7 +90,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
             var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
 
-            Assert.Equal(output, signinResult);
+            Assert.Equal(signinResult, output);
             userManagerMock.Verify();
             contextAccessorMock.Verify();
         }
@@ -107,7 +107,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
             userManagerMock.Setup(mock => mock.IsPasswordChangeRequiredAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(isPasswordChangeRequired)).Verifiable();
 
             var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
-            Assert.Equal(output, signinResult);
+            Assert.Equal(signinResult, output);
             userManagerMock.Verify();
         }
 
@@ -129,7 +129,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
             var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
 
-            Assert.Equal(output, signinResult);
+            Assert.Equal(signinResult, output);
             contextAccessorMock.Verify();
         }
 
@@ -154,7 +154,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
             var output = await signinManager.RespondToTwoFactorChallengeAsync("2FACODE", true, false).ConfigureAwait(false);
 
-            Assert.Equal(output, SignInResult.Success);
+            Assert.Equal(SignInResult.Success, output);
             contextAccessorMock.Verify();
             userManagerMock.Verify();
         }
@@ -176,7 +176,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
             var output = await signinManager.RespondToTwoFactorChallengeAsync("2FACODE", true, false).ConfigureAwait(false);
 
-            Assert.Equal(output, SignInResult.Failed);
+            Assert.Equal(SignInResult.Failed, output);
             contextAccessorMock.Verify();
             userManagerMock.Verify();
         }
@@ -195,7 +195,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
             var output = await signinManager.GetTwoFactorAuthenticationUserAsync().ConfigureAwait(false);
 
-            Assert.Equal(output, cognitoUser);
+            Assert.Equal(cognitoUser, output);
             contextAccessorMock.Verify();
             userManagerMock.Verify();
         }

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
@@ -1,0 +1,259 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.CognitoIdentityProvider;
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public class CognitoSigninManagerTest : ManagerTestBase
+    {
+        private CognitoSignInManager<CognitoUser> signinManager;
+        private Mock<CognitoUserManager<CognitoUser>> userManagerMock;
+
+        public CognitoSigninManagerTest() : base()
+        {
+            userManagerMock = new Mock<CognitoUserManager<CognitoUser>>(storeMock.Object, null, null, null, null, null, null, null, null);
+            claimsFactoryMock = new Mock<CognitoUserClaimsPrincipalFactory<CognitoUser>>(userManagerMock.Object, optionsAccessorMock.Object);
+            signinManager = new CognitoSignInManager<CognitoUser>(userManagerMock.Object, contextAccessorMock.Object, claimsFactoryMock.Object, optionsAccessorMock.Object, loggerMock.Object, schemesMock.Object);
+        }
+
+        [Fact]
+        public async void Test_GivenAnUnknownUser_WhenPasswordSignIn_ThenReturnSigninResultFailed()
+        {
+            var signinResult = SignInResult.Failed;
+            CognitoUser user = null;
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(user)).Verifiable();
+            var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
+            Assert.Equal(output, signinResult);
+            userManagerMock.Verify();
+        }
+        
+        [Fact]
+        public async void Test_GivenAnUserWithWrongPassword_WhenPasswordSignIn_ThenReturnSigninResultFailed()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            AuthFlowResponse authFlowResponse = null;
+            bool isPasswordChangeRequired = false;
+            var signinResult = SignInResult.Failed;
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
+            userManagerMock.Setup(mock => mock.CheckPasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<string>())).Returns(Task.FromResult(authFlowResponse)).Verifiable();
+            userManagerMock.Setup(mock => mock.IsPasswordChangeRequiredAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(isPasswordChangeRequired)).Verifiable();
+
+            var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
+
+            Assert.Equal(output, signinResult);
+            userManagerMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUserWithNo2FA_WhenPasswordSignIn_ThenReturnSigninResultSuccess()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
+            bool isPasswordChangeRequired = false;
+            var signinResult = SignInResult.Success;
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
+            userManagerMock.Setup(mock => mock.IsPasswordChangeRequiredAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(isPasswordChangeRequired)).Verifiable();
+
+            userManagerMock.Setup(mock => mock.CheckPasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(authFlowResponse))
+                .Callback(() => cognitoUser.SessionTokens = new CognitoUserSession("idToken", "accessToken", "refreshToken", DateTime.Now, DateTime.Now.AddDays(1))).Verifiable();
+
+            userManagerMock.Setup(mock => mock.GetClaimsAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(new List<Claim>() as IList<Claim>)).Verifiable();
+            userManagerMock.Setup(mock => mock.GetRolesAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(new List<string>() as IList<string>)).Verifiable();
+
+            var context = MockUtils.MockContext(cognitoUser, IdentityConstants.TwoFactorUserIdScheme);
+
+            contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
+
+            var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
+
+            Assert.Equal(output, signinResult);
+            userManagerMock.Verify();
+            contextAccessorMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUserWithPasswordChangeRequired_WhenPasswordSignIn_ThenReturnSigninResultPassowrdChangeRequired()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
+            bool isPasswordChangeRequired = true;
+            var signinResult = CognitoSignInResult.PasswordChangeRequired;
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
+            userManagerMock.Setup(mock => mock.IsPasswordChangeRequiredAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(isPasswordChangeRequired)).Verifiable();
+
+            var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
+            Assert.Equal(output, signinResult);
+            userManagerMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUserWith2FA_WhenPasswordSignIn_ThenReturnSigninResultTwoFactorRequired()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            bool isPasswordChangeRequired = false;
+            var signinResult = SignInResult.TwoFactorRequired;
+            var authFlowResponse = new AuthFlowResponse("2FASESSIONID", null, ChallengeNameType.SMS_MFA, null, null);
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser));
+            userManagerMock.Setup(mock => mock.CheckPasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<string>())).Returns(Task.FromResult(authFlowResponse));
+            userManagerMock.Setup(mock => mock.IsPasswordChangeRequiredAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(isPasswordChangeRequired));
+
+            var context = MockUtils.MockContext(cognitoUser, IdentityConstants.TwoFactorUserIdScheme);
+
+            contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
+
+            var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
+
+            Assert.Equal(output, signinResult);
+            contextAccessorMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUserWith2FA_WhenRespondToTwoFactorChallengeWithCorrectCode_ThenReturnSigninResultSuccess()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var context = MockUtils.MockContext(cognitoUser, IdentityConstants.TwoFactorUserIdScheme);
+
+            contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
+
+            var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
+
+            userManagerMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(authFlowResponse))
+                .Callback(() => cognitoUser.SessionTokens = new CognitoUserSession("idToken", "accessToken", "refreshToken", DateTime.Now, DateTime.Now.AddDays(1))).Verifiable();
+
+            userManagerMock.Setup(mock => mock.GetClaimsAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(new List<Claim>() as IList<Claim>)).Verifiable();
+            userManagerMock.Setup(mock => mock.GetRolesAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(new List<string>() as IList<string>)).Verifiable();
+
+            var output = await signinManager.RespondToTwoFactorChallengeAsync("2FACODE", true, false).ConfigureAwait(false);
+
+            Assert.Equal(output, SignInResult.Success);
+            contextAccessorMock.Verify();
+            userManagerMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUserWith2FA_WhenRespondToTwoFactorChallengeWithWrongCode_ThenReturnSigninResultFailed()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var context = MockUtils.MockContext(cognitoUser, IdentityConstants.TwoFactorUserIdScheme);
+
+            contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
+
+            AuthFlowResponse authFlowResponse = null;
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
+
+            userManagerMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(authFlowResponse)).Verifiable();
+
+            var output = await signinManager.RespondToTwoFactorChallengeAsync("2FACODE", true, false).ConfigureAwait(false);
+
+            Assert.Equal(output, SignInResult.Failed);
+            contextAccessorMock.Verify();
+            userManagerMock.Verify();
+        }
+
+
+        [Fact]
+        public async void Test_GivenAUserSignedInWith2FAContext_WhenGetTwoFactorAuthenticationUser_ThenTheUserIsRetrieved()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+
+            var context = MockUtils.MockContext(cognitoUser, IdentityConstants.TwoFactorUserIdScheme);
+
+            contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
+
+            var output = await signinManager.GetTwoFactorAuthenticationUserAsync().ConfigureAwait(false);
+
+            Assert.Equal(output, cognitoUser);
+            contextAccessorMock.Verify();
+            userManagerMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUserSignedIn_WhenSignOut_ThenTheUserIsSignedOut()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var context = MockUtils.MockContext(cognitoUser, IdentityConstants.ApplicationScheme);
+
+            contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
+
+            await signinManager.SignOutAsync().ConfigureAwait(false);
+
+            // SessionTokens should be flushed when signing out
+            Assert.Null(cognitoUser.SessionTokens);
+
+            userManagerMock.Verify();
+
+        }
+
+        #region ExceptionTests
+        [Fact]
+        public async void Test_GivenUserIdAndLockoutActivated_WhenPasswordSignIn_ThenThrowsNotSupportedException()
+        {
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() => signinManager.PasswordSignInAsync("userId", "password", true, lockoutOnFailure: true)).ConfigureAwait(false);
+            Assert.Equal("Lockout is not enabled for the CognitoUserManager.", ex.Message);
+        }
+
+        [Fact]
+        public async void Test_GivenUserAndLockoutActivated_WhenPasswordSignIn_ThenThrowsNotSupportedException()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() => signinManager.PasswordSignInAsync(cognitoUser, "password", true, lockoutOnFailure: true)).ConfigureAwait(false);
+            Assert.Equal("Lockout is not enabled for the CognitoUserManager.", ex.Message);
+        }
+
+        [Fact]
+        public async void Test_GivenUserAndLockoutActivated_WhenCheckPasswordSignIn_ThenThrowsNotSupportedException()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(() => signinManager.CheckPasswordSignInAsync(cognitoUser, "password", lockoutOnFailure: true)).ConfigureAwait(false);
+            Assert.Equal("Lockout is not enabled for the CognitoUserManager.", ex.Message);
+        }
+
+        [Fact]
+        public async void Test_GivenNullUser_WhenCheckPasswordSignIn_ThenThrowsArgumentNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => signinManager.CheckPasswordSignInAsync(null, "password", false)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenNullUser_WhenPasswordSignIn_ThenThrowsArgumentNullException()
+        {
+            CognitoUser user = null;
+            await Assert.ThrowsAsync<ArgumentNullException>(() => signinManager.PasswordSignInAsync(user, "password", false, false)).ConfigureAwait(false);
+        }
+        #endregion
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
@@ -1,0 +1,159 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public class CognitoUserManagerTest : ManagerTestBase
+    {
+        private CognitoUserManager<CognitoUser> userManager;
+        
+
+        public CognitoUserManagerTest() : base()
+        {
+            
+
+            userManager = new CognitoUserManager<CognitoUser>(userStoreMock.Object, 
+                optionsAccessorMock.Object, 
+                passwordHasherMock.Object,
+                new List<IUserValidator<CognitoUser>>() { userValidatorsMock.Object },
+                new List<IPasswordValidator<CognitoUser>>() { passwordValidatorsMock.Object }, 
+                keyNormalizer, 
+                errorsMock.Object, 
+                servicesMock.Object, 
+                loggerUserManagerMock.Object);
+        }
+
+        [Fact]
+        public async void Test_GivenAnUser_WhenCheckPassword_ThenResponseIsNotAltered()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
+            userStoreMock.Setup(mock => mock.StartValidatePasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(authFlowResponse)).Verifiable();
+
+            var output = await userManager.CheckPasswordAsync(cognitoUser, "password").ConfigureAwait(false);
+            Assert.Equal(authFlowResponse, output);
+            userStoreMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUser_WhenRespondToTwoFactorChallenge_ThenResponseIsNotAltered()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
+            userStoreMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(authFlowResponse)).Verifiable();
+
+            var output = await userManager.RespondToTwoFactorChallengeAsync(cognitoUser, "2FACODE", "SessionId").ConfigureAwait(false);
+            Assert.Equal(authFlowResponse, output);
+            userStoreMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUser_WhenSetTwoFactorEnabled_ThenReturnIdentityResultSuccess()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var output = await userManager.SetTwoFactorEnabledAsync(cognitoUser, true).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            userStoreMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUser_WhenChangePassword_ThenResponseIsNotAltered()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            userStoreMock.Setup(mock => mock.ChangePasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
+
+            var output = await userManager.ChangePasswordAsync(cognitoUser, "old", "new").ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            userStoreMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUser_WhenIsPasswordChangeRequired_ThenResponseIsNotAltered()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object, null, "FORCE_CHANGE_PASSWORD");
+            var output = await userManager.IsPasswordChangeRequiredAsync(cognitoUser).ConfigureAwait(false);
+            Assert.True(output);
+            userStoreMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUserAndNewPassword_WhenResetPassword_ThenResponseIsNotAltered()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+
+            userStoreMock.Setup(mock => mock.ChangePasswordWithTokenAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
+
+            var output = await userManager.ResetPasswordAsync(cognitoUser, "token", "newPassword").ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            userStoreMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAnUser_WhenResetPassword_ThenResponseIsNotAltered()
+        {
+            var cognitoUser = new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+
+            userStoreMock.Setup(mock => mock.ResetPasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
+
+            var output = await userManager.ResetPasswordAsync(cognitoUser).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            userStoreMock.Verify();
+        }
+
+        #region ExceptionTests
+
+        [Fact]
+        public async void Test_GivenANullUser_WhenCheckPassword_ThenThrowsArgumentNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => userManager.CheckPasswordAsync(null, "password")).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenANullUser_WhenRespondToTwoFactorChallenge_ThenThrowsArgumentNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => userManager.RespondToTwoFactorChallengeAsync(null, "2FACODE", "SessionId")).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenANullUser_WhenSetTwoFactorEnabled_ThenThrowsArgumentNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => userManager.SetTwoFactorEnabledAsync(null, true)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenANullUser_WhenChangePassword_ThenThrowsArgumentNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => userManager.ChangePasswordAsync(null, "old", "new")).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenANullUser_WhenResetPasswordAsync_ThenThrowsArgumentNullException()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => userManager.ResetPasswordAsync(null)).ConfigureAwait(false);
+        }
+
+
+        #endregion
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
@@ -29,11 +29,9 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
     {
         private CognitoUserManager<CognitoUser> userManager;
         
-
         public CognitoUserManagerTest() : base()
         {
             
-
             userManager = new CognitoUserManager<CognitoUser>(userStoreMock.Object, 
                 optionsAccessorMock.Object, 
                 passwordHasherMock.Object,
@@ -291,8 +289,6 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         {
             await Assert.ThrowsAsync<NotSupportedException>(() => userManager.ChangeEmailAsync(null, null, null)).ConfigureAwait(false);
         }
-
-
 
         #endregion
     }

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/ManagerTestBase.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/ManagerTestBase.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.AspNetCore.Identity.Cognito.Exceptions;
+using Amazon.CognitoIdentityProvider;
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public class ManagerTestBase
+    {
+        protected Mock<IHttpContextAccessor> contextAccessorMock;
+        protected Mock<CognitoUserClaimsPrincipalFactory<CognitoUser>> claimsFactoryMock;
+        protected Mock<IOptions<IdentityOptions>> optionsAccessorMock;
+        protected Mock<ILogger<SignInManager<CognitoUser>>> loggerMock;
+        protected Mock<IAuthenticationSchemeProvider> schemesMock;
+        protected Mock<IAmazonCognitoIdentityProvider> cognitoClientMock;
+        protected Mock<CognitoUserPool> cognitoPoolMock;
+        protected Mock<CognitoUserStore<CognitoUser>> storeMock;
+        protected Mock<CognitoIdentityErrorDescriber> errorsMock;
+        
+
+        public ManagerTestBase()
+        {
+            cognitoClientMock = new Mock<IAmazonCognitoIdentityProvider>();
+            cognitoPoolMock = new Mock<CognitoUserPool>("region_poolName", "clientID", cognitoClientMock.Object, null);
+            errorsMock = new Mock<CognitoIdentityErrorDescriber>();
+            storeMock = new Mock<CognitoUserStore<CognitoUser>>(cognitoClientMock.Object, cognitoPoolMock.Object, errorsMock.Object);
+            optionsAccessorMock = new Mock<IOptions<IdentityOptions>>();
+            var idOptions = new IdentityOptions();
+            idOptions.Lockout.AllowedForNewUsers = false;
+            optionsAccessorMock.Setup(o => o.Value).Returns(idOptions);
+            contextAccessorMock = new Mock<IHttpContextAccessor>();
+            loggerMock = new Mock<ILogger<SignInManager<CognitoUser>>>();
+            schemesMock = new Mock<IAuthenticationSchemeProvider>();
+        }
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/ManagerTestBase.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/ManagerTestBase.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using System;
 
 namespace Amazon.AspNetCore.Identity.Cognito.Test
 {
@@ -30,27 +31,38 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         protected Mock<IHttpContextAccessor> contextAccessorMock;
         protected Mock<CognitoUserClaimsPrincipalFactory<CognitoUser>> claimsFactoryMock;
         protected Mock<IOptions<IdentityOptions>> optionsAccessorMock;
-        protected Mock<ILogger<SignInManager<CognitoUser>>> loggerMock;
+        protected Mock<ILogger<SignInManager<CognitoUser>>> loggerSigninManagerMock;
         protected Mock<IAuthenticationSchemeProvider> schemesMock;
         protected Mock<IAmazonCognitoIdentityProvider> cognitoClientMock;
         protected Mock<CognitoUserPool> cognitoPoolMock;
-        protected Mock<CognitoUserStore<CognitoUser>> storeMock;
         protected Mock<CognitoIdentityErrorDescriber> errorsMock;
-        
+        protected Mock<CognitoUserStore<CognitoUser>> userStoreMock;
+        protected Mock<IPasswordHasher<CognitoUser>> passwordHasherMock;
+        protected Mock<IUserValidator<CognitoUser>> userValidatorsMock;
+        protected Mock<IPasswordValidator<CognitoUser>> passwordValidatorsMock;
+        protected CognitoKeyNormalizer keyNormalizer;
+        protected Mock<IServiceProvider> servicesMock; 
+        protected Mock<ILogger<UserManager<CognitoUser>>> loggerUserManagerMock;
 
         public ManagerTestBase()
         {
             cognitoClientMock = new Mock<IAmazonCognitoIdentityProvider>();
             cognitoPoolMock = new Mock<CognitoUserPool>("region_poolName", "clientID", cognitoClientMock.Object, null);
             errorsMock = new Mock<CognitoIdentityErrorDescriber>();
-            storeMock = new Mock<CognitoUserStore<CognitoUser>>(cognitoClientMock.Object, cognitoPoolMock.Object, errorsMock.Object);
             optionsAccessorMock = new Mock<IOptions<IdentityOptions>>();
             var idOptions = new IdentityOptions();
             idOptions.Lockout.AllowedForNewUsers = false;
             optionsAccessorMock.Setup(o => o.Value).Returns(idOptions);
             contextAccessorMock = new Mock<IHttpContextAccessor>();
-            loggerMock = new Mock<ILogger<SignInManager<CognitoUser>>>();
+            loggerSigninManagerMock = new Mock<ILogger<SignInManager<CognitoUser>>>();
             schemesMock = new Mock<IAuthenticationSchemeProvider>();
+            userStoreMock = new Mock<CognitoUserStore<CognitoUser>>(cognitoClientMock.Object, cognitoPoolMock.Object, errorsMock.Object);
+            passwordHasherMock = new Mock<IPasswordHasher<CognitoUser>>();
+            userValidatorsMock = new Mock<IUserValidator<CognitoUser>>();
+            passwordValidatorsMock = new Mock<IPasswordValidator<CognitoUser>>();
+            keyNormalizer = new CognitoKeyNormalizer();
+            servicesMock = new Mock<IServiceProvider>();
+            loggerUserManagerMock = new Mock<ILogger<UserManager<CognitoUser>>>();
         }
     }
 }

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/ManagerTestBase.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/ManagerTestBase.cs
@@ -64,5 +64,10 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
             servicesMock = new Mock<IServiceProvider>();
             loggerUserManagerMock = new Mock<ILogger<UserManager<CognitoUser>>>();
         }
+
+        public CognitoUser GetCognitoUser()
+        {
+            return new CognitoUser("userId", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+        }
     }
 }

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/MockUtils.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/MockUtils.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public static class MockUtils
+    {
+        public const string loginProvider = "login";
+        public const string providerKey = "fookey";
+
+        /// <summary>
+        /// This creates an http context.
+        /// </summary>
+        /// <param name="cognitoUser">The Cognito User to link to the context</param>
+        /// <param name="scheme">The scheme to signin the user into</param>
+        /// <returns></returns>
+        public static DefaultHttpContext MockContext(CognitoUser cognitoUser, string scheme)
+        {
+            var context = new DefaultHttpContext();
+            var authMock = new Mock<IAuthenticationService>();
+            var userPrincipal = new ClaimsPrincipal();
+            userPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>() {
+                    new Claim(ClaimTypes.Name, cognitoUser.UserID),
+                    new Claim(providerKey, loginProvider),
+                    new Claim(ClaimTypes.AuthenticationMethod, providerKey)
+                }));
+            var authenticationTicket = new AuthenticationTicket(userPrincipal, scheme);
+            var authenticateResult = AuthenticateResult.Success(authenticationTicket);
+
+            context.RequestServices = new ServiceCollection().AddSingleton(authMock.Object).BuildServiceProvider();
+            authMock.Setup(a => a.AuthenticateAsync(context,
+               scheme)).Returns(Task.FromResult(authenticateResult)).Verifiable();
+
+            return context;
+        }
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/MockUtils.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/MockUtils.cs
@@ -54,5 +54,6 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
             return context;
         }
+
     }
 }


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3181

*Description of changes:* 
Adding 44 unit tests overall for the SigninManager and UserManager
Switched a few of the new managers/stores methods to virtual for test-ability. 

+ Fixed one bug on user sessions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
