### PR TITLE
Fixing a gap in logic in ChangePassword() when the user has to respond to a challenge

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
-    <Version>0.9.0</Version>
+    <Version>0.9.0.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.AspNetCore.Identity.Cognito</PackageId>
     <Title>ASP.NET Core Identity Provider for Amazon Cognito</Title>
@@ -18,6 +18,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
+    <AssemblyVersion>0.9.0.1</AssemblyVersion>
+    <FileVersion>0.9.0.1</FileVersion>
   </PropertyGroup>
 
     <Choose>


### PR DESCRIPTION
Fixing a gap in logic in ChangePassword() when the user has to respond to a challenge
Upgrading the version to 0.9.0.1 for NuGet release

*Issue #, if available:* N/A

*Description of changes:*

There is a gap when a user is created by an admin, and has a status forced to change password.
When calling user.ChangePasswordAsync() there is no session set because the user is facing an auth challenge.

This change responds to the challenge and changes the password.

Tested with various scenarios


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
