### PR TITLE
Removing sign-out overload causing a StackOverflowException

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
-    <Version>0.9.0.1</Version>
+    <Version>0.9.0.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.AspNetCore.Identity.Cognito</PackageId>
     <Title>ASP.NET Core Identity Provider for Amazon Cognito</Title>
@@ -18,8 +18,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>0.9.0.1</AssemblyVersion>
-    <FileVersion>0.9.0.1</FileVersion>
+    <AssemblyVersion>0.9.0.2</AssemblyVersion>
+    <FileVersion>0.9.0.2</FileVersion>
   </PropertyGroup>
 
     <Choose>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -200,28 +200,6 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
-        /// Signs the current user out of Cognito in addition of signin the user out of the application.
-        /// </summary>
-        /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public override async Task SignOutAsync()
-        {
-            // Retrieve the current signed in CognitoUser and log him out first
-            var result = await Context.AuthenticateAsync(IdentityConstants.ApplicationScheme).ConfigureAwait(false);
-            if (result?.Principal != null)
-            {
-                var user = await _userManager.FindByIdAsync(result.Principal.FindFirstValue(ClaimTypes.Name)).ConfigureAwait(false);
-                if (user != null)
-                {
-                    user.SignOut();
-                }
-            }
-           
-            await Context.SignOutAsync(IdentityConstants.ApplicationScheme).ConfigureAwait(false);
-            await Context.SignOutAsync(IdentityConstants.ExternalScheme).ConfigureAwait(false);
-            await Context.SignOutAsync(IdentityConstants.TwoFactorUserIdScheme).ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Checks if the password needs to be changed for the specified <paramref name="user"/>.
         /// </summary>
         /// <param name="user">The user to check if the password needs to be changed.</param>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserClaimsPrincipalFactory.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserClaimsPrincipalFactory.cs
@@ -62,8 +62,8 @@ namespace Amazon.AspNetCore.Identity.Cognito
 
             claimToAttributesMapping.ToList().ForEach(claim => MapClaimTypesToCognito(claims, claim.Key, claim.Value));
 
-            var userNameClaimType = _identityOptions.ClaimsIdentity.UserNameClaimType;
-            claims.Add(new Claim(userNameClaimType, user.Username));
+            claims.Add(new Claim(_identityOptions.ClaimsIdentity.UserNameClaimType, user.Username));
+            claims.Add(new Claim(_identityOptions.ClaimsIdentity.UserIdClaimType, user.Username));
 
             var roles = await _userManager.GetRolesAsync(user).ConfigureAwait(false);
             var roleClaimType = _identityOptions.ClaimsIdentity.RoleClaimType;

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
@@ -183,24 +183,6 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
             userManagerMock.Verify();
         }
 
-        [Fact]
-        public async void Test_GivenAUserSignedIn_WhenSignOut_ThenTheUserIsSignedOut()
-        {
-            var cognitoUser = GetCognitoUser();
-            var context = MockUtils.MockContext(cognitoUser, IdentityConstants.ApplicationScheme);
-
-            contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
-            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
-
-            await signinManager.SignOutAsync().ConfigureAwait(false);
-
-            // SessionTokens should be flushed when signing out
-            Assert.Null(cognitoUser.SessionTokens);
-
-            userManagerMock.Verify();
-
-        }
-
         #region ExceptionTests
         [Fact]
         public async void Test_GivenUserIdAndLockoutActivated_WhenPasswordSignIn_ThenThrowsNotSupportedException()


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3224

*Description of changes:* Removing this overload. It is actually not needed, as the code is already signing out the user from the context, so it can not be retrieved later on.

Flushing the Cognito tokens is not mandatory, the user is removed from the principals anyways.
The store methods are using Admin apis, so the tokens are not used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
