### PR TITLE
New SigninResult object to make a distinction between a force change password and a required password reset

### DIFF
--- a/samples/Samples/Samples.csproj
+++ b/samples/Samples/Samples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.AspNetCore.Identity.Cognito" Version="0.9.0" />
+    <PackageReference Include="Amazon.AspNetCore.Identity.Cognito" Version="0.9.0.2" />
     <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" PrivateAssets="All" />

--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
-    <Version>0.9.0.2</Version>
+    <Version>0.9.0.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.AspNetCore.Identity.Cognito</PackageId>
     <Title>ASP.NET Core Identity Provider for Amazon Cognito</Title>
@@ -18,8 +18,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>0.9.0.2</AssemblyVersion>
-    <FileVersion>0.9.0.2</FileVersion>
+    <AssemblyVersion>0.9.0.3</AssemblyVersion>
+    <FileVersion>0.9.0.3</FileVersion>
   </PropertyGroup>
 
     <Choose>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSignInResult.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSignInResult.cs
@@ -26,10 +26,22 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public static readonly CognitoSignInResult PasswordChangeRequired = new CognitoSignInResult { RequiresPasswordChange = true };
 
         /// <summary>
+        ///  Returns a CognitoSignInResult that represents a required password reset.
+        /// </summary>
+        /// <returns>A CognitoSignInResult that represents a required password reset.</returns>
+        public static readonly CognitoSignInResult PasswordResetRequired = new CognitoSignInResult { RequiresPasswordReset = true };
+
+        /// <summary>
         ///  Returns a flag indication whether changing the password is required.
         /// </summary>
         /// <returns>A flag indication whether changing the password is required.</returns>
         public bool RequiresPasswordChange { get; protected set; }
+
+        /// <summary>
+        ///  Returns a flag indication whether reseting the password is required.
+        /// </summary>
+        /// <returns>A flag indication whether reseting the password is required.</returns>
+        public bool RequiresPasswordReset { get; protected set; }
 
         /// <summary>
         /// Converts the value of the current <see cref="CognitoSignInResult"/> object to its equivalent string representation.
@@ -41,6 +53,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
                    IsNotAllowed ? "NotAllowed" :
                    RequiresTwoFactor ? "RequiresTwoFactor" :
                    RequiresPasswordChange ? "RequiresPasswordChange" :
+                   RequiresPasswordReset ? "RequiresPasswordReset" :
                    Succeeded ? "Succeeded" : "Failed";
         }
     }

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -139,7 +139,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
                 throw new ArgumentNullException(nameof(user));
             }
 
-            // Prechecks if the user password needs to be changed
+            // Prechecks if the user password needs to be changed or reset
             var error = await PreSignInCheck(user).ConfigureAwait(false);
             if (error != null)
             {
@@ -196,6 +196,10 @@ namespace Amazon.AspNetCore.Identity.Cognito
             {
                 return CognitoSignInResult.PasswordChangeRequired;
             }
+            if (await IsPasswordResetRequiredAsync(user).ConfigureAwait(false))
+            {
+                return CognitoSignInResult.PasswordResetRequired;
+            }
             return null;
         }
 
@@ -207,6 +211,16 @@ namespace Amazon.AspNetCore.Identity.Cognito
         protected Task<bool> IsPasswordChangeRequiredAsync(TUser user)
         {
             return _userManager.IsPasswordChangeRequiredAsync(user);
+        }
+
+        /// <summary>
+        /// Checks if the password needs to be reset for the specified <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">The user to check if the password needs to be reset.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a boolean set to true if the password needs to be reset, false otherwise.</returns>
+        protected Task<bool> IsPasswordResetRequiredAsync(TUser user)
+        {
+            return _userManager.IsPasswordResetRequiredAsync(user);
         }
 
         /// <summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -146,6 +146,17 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
+        /// Checks if the password needs to be reset for the specified <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">The user to check if the password needs to be reset.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a boolean set to true if the password needs to be reset, false otherwise.</returns>
+        public virtual Task<bool> IsPasswordResetRequiredAsync(TUser user)
+        {
+            ThrowIfDisposed();
+            return _userStore.IsPasswordResetRequiredAsync(user, CancellationToken);
+        }
+
+        /// <summary>
         /// Resets the <paramref name="user"/>'s password to the specified <paramref name="newPassword"/> after
         /// validating the given password reset <paramref name="token"/>.
         /// </summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -183,8 +183,20 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public virtual Task<bool> IsPasswordChangeRequiredAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            bool IsPasswordChangeRequired = user.Status.Equals(UserStatusForceChangePassword, StringComparison.InvariantCulture) || user.Status.Equals(UserStatusResetRequired, StringComparison.InvariantCulture);
+            bool IsPasswordChangeRequired = user.Status.Equals(UserStatusForceChangePassword, StringComparison.InvariantCulture);
             return Task.FromResult(IsPasswordChangeRequired);
+        }
+
+        /// <summary>
+        /// Checks if the password needs to be reset for the specified <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">The user to check if the password needs to be reset.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a boolean set to true if the password needs to be reset, false otherwise.</returns>
+        public virtual Task<bool> IsPasswordResetRequiredAsync(TUser user, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            bool IsPasswordResetRequired = user.Status.Equals(UserStatusResetRequired, StringComparison.InvariantCulture);
+            return Task.FromResult(IsPasswordResetRequired);
         }
 
         /// <summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
@@ -68,6 +68,13 @@ namespace Amazon.AspNetCore.Identity.Cognito
         Task<bool> IsPasswordChangeRequiredAsync(TUser user, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Checks if the password needs to be reset for the specified <paramref name="user"/>.
+        /// </summary>
+        /// <param name="user">The user to check if the password needs to be reset.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing a boolean set to true if the password needs to be reset, false otherwise.</returns>
+        Task<bool> IsPasswordResetRequiredAsync(TUser user, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Resets the <paramref name="user"/>'s password and sends the confirmation token to the user 
         /// via email or sms depending on the user pool policy.
         /// </summary>

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
@@ -49,7 +49,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
         
         [Fact]
-        public async void Test_GivenAnUserWithWrongPassword_WhenPasswordSignIn_ThenReturnSigninResultFailed()
+        public async void Test_GivenAUserWithWrongPassword_WhenPasswordSignIn_ThenReturnSigninResultFailed()
         {
             AuthFlowResponse authFlowResponse = null;
             bool isPasswordChangeRequired = false;
@@ -63,7 +63,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUserWithNo2FA_WhenPasswordSignIn_ThenReturnSigninResultSuccess()
+        public async void Test_GivenAUserWithNo2FA_WhenPasswordSignIn_ThenReturnSigninResultSuccess()
         {
             var cognitoUser = GetCognitoUser();
             var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
@@ -89,7 +89,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUserWithPasswordChangeRequired_WhenPasswordSignIn_ThenReturnSigninResultPassowrdChangeRequired()
+        public async void Test_GivenAUserWithPasswordChangeRequired_WhenPasswordSignIn_ThenReturnSigninResultPassowrdChangeRequired()
         {
             bool isPasswordChangeRequired = true;
             var signinResult = CognitoSignInResult.PasswordChangeRequired;
@@ -103,7 +103,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUserWithPasswordResetRequired_WhenPasswordSignIn_ThenReturnSigninResultPassowrdResetRequired()
+        public async void Test_GivenAUserWithPasswordResetRequired_WhenPasswordSignIn_ThenReturnSigninResultPassowrdResetRequired()
         {
             bool isPasswordResetRequired = true;
             var signinResult = CognitoSignInResult.PasswordResetRequired;

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
@@ -103,6 +103,20 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
+        public async void Test_GivenAnUserWithPasswordResetRequired_WhenPasswordSignIn_ThenReturnSigninResultPassowrdResetRequired()
+        {
+            bool isPasswordResetRequired = true;
+            var signinResult = CognitoSignInResult.PasswordResetRequired;
+
+            userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(GetCognitoUser())).Verifiable();
+            userManagerMock.Setup(mock => mock.IsPasswordResetRequiredAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(isPasswordResetRequired)).Verifiable();
+
+            var output = await signinManager.PasswordSignInAsync("userId", "password", true, false).ConfigureAwait(false);
+            Assert.Equal(signinResult, output);
+            userManagerMock.Verify();
+        }
+
+        [Fact]
         public async void Test_GivenAUserWith2FA_WhenPasswordSignIn_ThenReturnSigninResultTwoFactorRequired()
         {
             var cognitoUser = GetCognitoUser();

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
@@ -44,7 +44,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenCheckPassword_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenCheckPassword_ThenResponseIsNotAltered()
         {
             var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
             userStoreMock.Setup(mock => mock.StartValidatePasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(authFlowResponse)).Verifiable();
@@ -54,7 +54,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenRespondToTwoFactorChallenge_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenRespondToTwoFactorChallenge_ThenResponseIsNotAltered()
         {
             var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
             userStoreMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(authFlowResponse)).Verifiable();
@@ -64,7 +64,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenSetTwoFactorEnabled_ThenReturnIdentityResultSuccess()
+        public async void Test_GivenAUser_WhenSetTwoFactorEnabled_ThenReturnIdentityResultSuccess()
         {
             var output = await userManager.SetTwoFactorEnabledAsync(GetCognitoUser(), true).ConfigureAwait(false);
             Assert.Equal(IdentityResult.Success, output);
@@ -72,7 +72,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenChangePassword_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenChangePassword_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.ChangePasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.ChangePasswordAsync(GetCognitoUser(), "old", "new").ConfigureAwait(false);
@@ -81,7 +81,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenIsPasswordChangeRequired_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenIsPasswordChangeRequired_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.IsPasswordChangeRequiredAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true)).Verifiable();
             var output = await userManager.IsPasswordChangeRequiredAsync(GetCognitoUser()).ConfigureAwait(false);
@@ -90,7 +90,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUserAndNewPassword_WhenResetPassword_ThenResponseIsNotAltered()
+        public async void Test_GivenAUserAndNewPassword_WhenResetPassword_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.ChangePasswordWithTokenAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.ResetPasswordAsync(GetCognitoUser(), "token", "newPassword").ConfigureAwait(false);
@@ -99,7 +99,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenSendEmailOrPhoneConfirmationToken_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenSendEmailOrPhoneConfirmationToken_ThenResponseIsNotAltered()
         {
             var cognitoUser = GetCognitoUser();
             userStoreMock.Setup(mock => mock.GetUserAttributeVerificationCodeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
@@ -111,7 +111,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenCreate_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenCreate_ThenResponseIsNotAltered()
         {
             var cognitoUser = GetCognitoUser();
             userStoreMock.Setup(mock => mock.CreateAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
@@ -125,7 +125,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenResetPassword_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenResetPassword_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.ResetPasswordAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.ResetPasswordAsync(GetCognitoUser()).ConfigureAwait(false);
@@ -134,7 +134,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenConfirmEmailOrPhoneNumber_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenConfirmEmailOrPhoneNumber_ThenResponseIsNotAltered()
         {
             var cognitoUser = GetCognitoUser();
             userStoreMock.Setup(mock => mock.VerifyUserAttributeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
@@ -146,7 +146,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenConfirmSignUp_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenConfirmSignUp_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.ConfirmSignUpAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.ConfirmSignUpAsync(GetCognitoUser(), "code", true).ConfigureAwait(false);
@@ -155,7 +155,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenAdminConfirmSignUp_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenAdminConfirmSignUp_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.AdminConfirmSignUpAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.AdminConfirmSignUpAsync(GetCognitoUser()).ConfigureAwait(false);
@@ -164,7 +164,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenSetPhoneNumber_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenSetPhoneNumber_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.SetPhoneNumberAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(0)).Verifiable();
             userStoreMock.Setup(mock => mock.UpdateAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
@@ -174,7 +174,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenSetEmail_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenSetEmail_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.SetEmailAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(0)).Verifiable();
             userStoreMock.Setup(mock => mock.UpdateAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
@@ -184,7 +184,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenUpdateUser_ThenResponseIsNotAltered()
+        public async void Test_GivennUser_WhenUpdateUser_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.UpdateAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.UpdateAsync(GetCognitoUser()).ConfigureAwait(false);
@@ -193,7 +193,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenAddClaims_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenAddClaims_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.AddClaimsAsync(It.IsAny<CognitoUser>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.AddClaimsAsync(GetCognitoUser(), new List<Claim>()).ConfigureAwait(false);
@@ -202,7 +202,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUser_WhenRemoveClaims_ThenResponseIsNotAltered()
+        public async void Test_GivenAUser_WhenRemoveClaims_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.RemoveClaimsAsync(It.IsAny<CognitoUser>(), It.IsAny<IEnumerable<Claim>>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
             var output = await userManager.RemoveClaimsAsync(GetCognitoUser(), new List<Claim>()).ConfigureAwait(false);
@@ -255,7 +255,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUserAndNullListOfClaim_WhenAddClaims_ThenThrowsArgumentNullException()
+        public async void Test_GivenAUserAndNullListOfClaim_WhenAddClaims_ThenThrowsArgumentNullException()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(() => userManager.AddClaimsAsync(GetCognitoUser(), null)).ConfigureAwait(false);
         }
@@ -267,7 +267,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
-        public async void Test_GivenAnUserAndNullListOfClaim_WhenRemoveClaims_ThenThrowsArgumentNullException()
+        public async void Test_GivenAUserAndNullListOfClaim_WhenRemoveClaims_ThenThrowsArgumentNullException()
         {
             await Assert.ThrowsAsync<ArgumentNullException>(() => userManager.RemoveClaimsAsync(GetCognitoUser(), null)).ConfigureAwait(false);
         }


### PR DESCRIPTION
New SigninResult object to make a distinction between a force change password and a required password reset

*Issue #, if available:* DOTNET-3254

*Description of changes:* Added a new property to the CognitoSigninResult to discern when the user password needs to be changed depending on the status.

See https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/44 for background


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
