### PR TITLE
Checking if the user attribute is there at all

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
-    <Version>0.9.0.3</Version>
+    <Version>0.9.0.4</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.AspNetCore.Identity.Cognito</PackageId>
     <Title>ASP.NET Core Identity Provider for Amazon Cognito</Title>
@@ -18,8 +18,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>0.9.0.3</AssemblyVersion>
-    <FileVersion>0.9.0.3</FileVersion>
+    <AssemblyVersion>0.9.0.4</AssemblyVersion>
+    <FileVersion>0.9.0.4</FileVersion>
   </PropertyGroup>
 
     <Choose>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -406,8 +406,15 @@ namespace Amazon.AspNetCore.Identity.Cognito
                 throw new NotAuthorizedException(string.Format("Reading attribute {0} is not allowed by the user pool client configuration.", attributeName));
             }
 
-            // This throws a KeyNotFoundException if the attribute name does not exist in the dictionnary.
-            return user.Attributes[attributeName];
+            // There is an edge case where an attribute might be there in the pool configuration, but not on the user profile
+            if (user.Attributes.ContainsKey(attributeName))
+            {
+                return user.Attributes[attributeName];
+            }
+            else
+            {
+                return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Checking if the user attribute is there at all, to support an edge case where the attribute might be in the pool, but not set on the user profile.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
