### PR TITLE
Adding UserManager.GetUsersAsync to expose the full list of users

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -507,6 +507,31 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
+        ///  Not supported: Returns an IQueryable of users if the store is an IQueryableUserStore
+        /// </summary>
+        public override IQueryable<TUser> Users
+        {
+            get
+            {
+                throw new NotSupportedException("This property is not supported. Use GetUsersAsync() instead.");
+            }
+        }
+
+        /// <summary>
+        /// Queries Cognito and returns all the users in the pool.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing a IEnumerable of CognitoUser.
+        /// </returns>
+        public virtual Task<IEnumerable<CognitoUser>> GetUsersAsync()
+        {
+            ThrowIfDisposed();
+            return _userStore.GetUsersAsync(CancellationToken);
+        }
+
+
+
+        /// <summary>
         /// Adds the specified <paramref name="claims"/> to the <paramref name="user"/>.
         /// </summary>
         /// <param name="user">The user to add the claim to.</param>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -529,8 +529,6 @@ namespace Amazon.AspNetCore.Identity.Cognito
             return _userStore.GetUsersAsync(CancellationToken);
         }
 
-
-
         /// <summary>
         /// Adds the specified <paramref name="claims"/> to the <paramref name="user"/>.
         /// </summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
@@ -96,6 +96,14 @@ namespace Amazon.AspNetCore.Identity.Cognito
         Task<IdentityResult> CreateAsync(TUser user, string password, IDictionary<string, string> validationData, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Queries Cognito and returns all the users in the pool.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing a IEnumerable of CognitoUser.
+        /// </returns>
+        Task<IEnumerable<CognitoUser>> GetUsersAsync(CancellationToken cancellationToken);
+
+        /// <summary>
         /// Registers the specified <paramref name="user"/> in Cognito with the given password,
         /// as an asynchronous operation. Also submits the validation data to the pre sign-up lambda trigger.
         /// </summary>

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
@@ -210,6 +210,24 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
             userStoreMock.Verify();
         }
 
+        [Fact]
+        public async void Test_GivenAListOfUsers_WhenGetUsers_ThenResponseIsNotAltered()
+        {
+            var user1 = new CognitoUser("userId1", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var user2 = new CognitoUser("userId2", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            var user3 = new CognitoUser("userId3", "clientId", cognitoPoolMock.Object, cognitoClientMock.Object);
+            IEnumerable<CognitoUser> users = new List<CognitoUser>()
+            {
+                user1,
+                user2,
+                user3
+            };
+            userStoreMock.Setup(mock => mock.GetUsersAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(users)).Verifiable();
+            var output = await userManager.GetUsersAsync().ConfigureAwait(false);
+            Assert.Equal(users, output);
+            userStoreMock.Verify();
+        }
+
         #region ExceptionTests
 
         [Fact]
@@ -288,6 +306,12 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         public async void Test_GivenAUser_WhenChangeEmail_ThenThrowsANotSupportedException()
         {
             await Assert.ThrowsAsync<NotSupportedException>(() => userManager.ChangeEmailAsync(null, null, null)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public void Test_GivenAListOfUsers_WhenCallingUsersProperty_ThenThrowsANotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() => userManager.Users);
         }
 
         #endregion


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3255

*Description of changes:*
Adding UserManager.GetUsersAsync to expose the full list of users
See https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/41 for some background.

In Identity, the UserManager.Users property returns the list of users as a lazy loaded Entity Framework collection.

The same behavior using the Cognito client would either trigger a service call (which we don't want for properties) or be tedious to implement, and the behavior of the property would be unclear to the developer.

I have choose to flag that property as NotSupported, with an exception message redirecting to a method instead, showing the intention of a service call.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
