### PR TITLE
Various stores unit test coverage

### DIFF
--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserClaimStoreTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserClaimStoreTest.cs
@@ -1,0 +1,120 @@
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.CognitoIdentityProvider.Model;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public partial class CognitoUserStoreTest
+    {
+        private AdminGetUserResponse GET_USER_RESPONSE = new AdminGetUserResponse
+        {
+            UserAttributes = new List<AttributeType>()
+                {
+                    new AttributeType()
+                    {
+                        Name = "Name1",
+                        Value = "Value1"
+                    },
+                    new AttributeType()
+                    {
+                        Name = "Name2",
+                        Value = "Value2"
+                    },
+                    new AttributeType()
+                    {
+                        Name = "Name2",
+                        Value = "Value2"
+                    }
+                }
+        };
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetClaims_ThenTheListOfClaimsIsRetrieved()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminGetUserAsync(It.IsAny<AdminGetUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(GET_USER_RESPONSE)).Verifiable();
+            var output = await _store.GetClaimsAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(GET_USER_RESPONSE.UserAttributes.Count, output.Count);
+            Assert.Equal(GET_USER_RESPONSE.UserAttributes[2].Name, output[2].Type);
+            Assert.Equal(GET_USER_RESPONSE.UserAttributes[1].Value, output[1].Value);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenAddClaimsWithPopulatedListOfClaims_ThenAdminUpdateUserAttributesIsCalled()
+        {
+            var claims = new List<Claim>()
+            {
+                new Claim("Name1", "Value1")
+            };
+            _cognitoClientMock.Setup(mock => mock.AdminUpdateUserAttributesAsync(It.IsAny<AdminUpdateUserAttributesRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminUpdateUserAttributesResponse())).Verifiable();
+            await _store.AddClaimsAsync(_userMock.Object, claims, CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenAddClaimsWithEmptyListOfClaims_ThenAdminUpdateUserAttributesIsNeverCalled()
+        {
+            var claims = new List<Claim>();
+            await _store.AddClaimsAsync(_userMock.Object, claims, CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify(mock => mock.AdminUpdateUserAttributesAsync(It.IsAny<AdminUpdateUserAttributesRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenRemoveClaimsWithAValidClaim_ThenAdminDeleteUserAttributesIsCalled()
+        {
+            var claims = new List<Claim>()
+            {
+                new Claim("Name1", "Value1")
+            };
+            _cognitoClientMock.Setup(mock => mock.AdminGetUserAsync(It.IsAny<AdminGetUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(GET_USER_RESPONSE)).Verifiable();
+            _cognitoClientMock.Setup(mock => mock.AdminDeleteUserAttributesAsync(It.IsAny<AdminDeleteUserAttributesRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminDeleteUserAttributesResponse())).Verifiable();
+            await _store.RemoveClaimsAsync(_userMock.Object, claims, CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenRemoveClaimsWithAnInvalidClaim_ThenAdminDeleteUserAttributesIsNeverCalled()
+        {
+            var claims = new List<Claim>()
+            {
+                new Claim("Unknown", "Unknown")
+            };
+            _cognitoClientMock.Setup(mock => mock.AdminGetUserAsync(It.IsAny<AdminGetUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(GET_USER_RESPONSE)).Verifiable();
+            _cognitoClientMock.Setup(mock => mock.AdminDeleteUserAttributesAsync(It.IsAny<AdminDeleteUserAttributesRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminDeleteUserAttributesResponse())).Verifiable();
+            await _store.RemoveClaimsAsync(_userMock.Object, claims, CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify(mock => mock.AdminDeleteUserAttributesAsync(It.IsAny<AdminDeleteUserAttributesRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenReplaceClaim_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.ReplaceClaimAsync(null, null, null, CancellationToken.None)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenAClaim_WhenGetUsersForClaim_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.GetUsersForClaimAsync(null, CancellationToken.None)).ConfigureAwait(false);
+        }
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserCognitoStoreTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserCognitoStoreTest.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.AspNetCore.Identity.Cognito.Exceptions;
+using Amazon.CognitoIdentityProvider;
+using Amazon.CognitoIdentityProvider.Model;
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public partial class CognitoUserStoreTest
+    {
+        private Mock<IAmazonCognitoIdentityProvider> _cognitoClientMock;
+        private Mock<CognitoUserPool> _cognitoPoolMock;
+        private Mock<CognitoIdentityErrorDescriber> _errorsMock;
+        private Mock<CognitoUser> _userMock;
+        private CognitoUserStore<CognitoUser> _store;
+
+        public CognitoUserStoreTest()
+        {
+            _cognitoClientMock = new Mock<IAmazonCognitoIdentityProvider>();
+            _cognitoPoolMock = new Mock<CognitoUserPool>("region_poolName", "clientID", _cognitoClientMock.Object, null);
+            _errorsMock = new Mock<CognitoIdentityErrorDescriber>();
+            _userMock = new Mock<CognitoUser>("userID", "clientID", _cognitoPoolMock.Object, _cognitoClientMock.Object, null, null, null, null);
+            _store = new CognitoUserStore<CognitoUser>(_cognitoClientMock.Object, _cognitoPoolMock.Object, _errorsMock.Object);
+        }
+
+        [Theory]
+        [InlineData("FORCE_CHANGE_PASSWORD", true)]
+        [InlineData("CONFIRMED", false)]
+        public async void Test_GivenAUserWithStatus_WhenIsPasswordChangeRequired_ThenResponseIsValid(string status, bool isPasswordChangeRequired)
+        {
+            var user = new CognitoUser("userID", "clientID", _cognitoPoolMock.Object, _cognitoClientMock.Object, null, status, null, null);
+            var output = await _store.IsPasswordChangeRequiredAsync(user, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(isPasswordChangeRequired, output);
+        }
+
+        [Theory]
+        [InlineData("RESET_REQUIRED", true)]
+        [InlineData("CONFIRMED", false)]
+        public async void Test_GivenAUserWithStatus_WhenIsPasswordResetRequired_ThenResponseIsValid(string status, bool isPasswordResetRequired)
+        {
+            var user = new CognitoUser("userID", "clientID", _cognitoPoolMock.Object, _cognitoClientMock.Object, null, status, null, null);
+            var output = await _store.IsPasswordResetRequiredAsync(user, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(isPasswordResetRequired, output);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenResetPassword_ThenTheRequestIsSuccessful()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminResetUserPasswordAsync(It.IsAny<AdminResetUserPasswordRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminResetUserPasswordResponse())).Verifiable();
+            var output = await _store.ResetPasswordAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenCreate_ThenTheUserGetsAddedToThePool()
+        {
+            var output = await _store.CreateAsync(_userMock.Object, "password", null, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenAdminConfirmSignUp_ThenTheRequestIsSuccessful()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminConfirmSignUpAsync(It.IsAny<AdminConfirmSignUpRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminConfirmSignUpResponse())).Verifiable();
+            var output = await _store.AdminConfirmSignUpAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetUserAttributeVerificationCodeOtherThanEmailOrPhone_ThenThrowsArgumentException()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(() => _store.GetUserAttributeVerificationCodeAsync(_userMock.Object, "UNKNOWN_ATTRIBUTE", CancellationToken.None)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetUserAttributeVerificationCode_ThenTheRequestIsSuccessfun()
+        {
+            _cognitoClientMock.Setup(mock => mock.GetUserAttributeVerificationCodeAsync(It.IsAny<GetUserAttributeVerificationCodeRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new GetUserAttributeVerificationCodeResponse())).Verifiable();
+            _userMock.Object.SessionTokens = new CognitoUserSession(null, null, null, DateTime.Now, DateTime.MaxValue);
+            var output = await _store.GetUserAttributeVerificationCodeAsync(_userMock.Object, CognitoAttributesConstants.PhoneNumber, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenVerifyUserAttribute_ThenTheRequestIsSuccessfun()
+        {
+            _cognitoClientMock.Setup(mock => mock.VerifyUserAttributeAsync(It.IsAny<VerifyUserAttributeRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new VerifyUserAttributeResponse())).Verifiable();
+            _userMock.Object.SessionTokens = new CognitoUserSession(null, null, null, DateTime.Now, DateTime.MaxValue);
+            var output = await _store.VerifyUserAttributeAsync(_userMock.Object, CognitoAttributesConstants.PhoneNumber, "code", CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            _cognitoClientMock.Verify();
+        }
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserEmailStoreTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserEmailStoreTest.cs
@@ -1,0 +1,70 @@
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.CognitoIdentityProvider.Model;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public partial class CognitoUserStoreTest
+    {
+        [Fact]
+        public async void Test_GivenAnEmail_WhenFindByEmail_ThenTheUserIsRetrieved()
+        {
+            var username = "UserName";
+            var status = "CONFIRMED";
+            var response = new ListUsersResponse()
+            {
+                Users = new List<UserType>()
+                {
+                    new UserType()
+                    {
+                        Username = username,
+                        UserStatus = status,
+                        Attributes = new List<AttributeType>()
+                    }
+                }
+            };
+            _cognitoClientMock.Setup(mock => mock.ListUsersAsync(It.IsAny<ListUsersRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response)).Verifiable();
+            var user = await _store.FindByEmailAsync("user@domain.tld", CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(username, user.Username);
+            Assert.Equal(status, user.Status);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetNormalizedEmail_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.GetNormalizedEmailAsync(_userMock.Object, CancellationToken.None)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenSetEmailConfirmed_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.SetEmailConfirmedAsync(_userMock.Object, true, CancellationToken.None)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenSetNormalizedEmail_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.SetNormalizedEmailAsync(_userMock.Object, "email", CancellationToken.None)).ConfigureAwait(false);
+        }
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserPhoneNumberStoreTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserPhoneNumberStoreTest.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using System;
+using System.Threading;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public partial class CognitoUserStoreTest
+    {
+        [Fact]
+        public async void Test_GivenAUser_WhenSetPhoneNumberConfirmed_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.SetPhoneNumberConfirmedAsync(_userMock.Object, true, CancellationToken.None)).ConfigureAwait(false);
+        }
+        
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserRoleStoreTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserRoleStoreTest.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.CognitoIdentityProvider.Model;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public partial class CognitoUserStoreTest
+    {
+        AdminListGroupsForUserResponse LIST_GROUPS_FOR_USERS_RESPONSE = new AdminListGroupsForUserResponse()
+        {
+            Groups = new List<GroupType>()
+                {
+                    new GroupType() { GroupName = "group1"},
+                    new GroupType() { GroupName = "group2"},
+                    new GroupType() { GroupName = "group3"},
+                }
+        };
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetUserId_ThenTheUserIdIsRetrieved()
+        {
+            var userId = await _store.GetUserIdAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(_userMock.Object.UserID, userId);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetUserName_ThenTheUserNameIsRetrieved()
+        {
+            var userName = await _store.GetUserNameAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(_userMock.Object.Username, userName);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenDelete_ThenAdminDeleteUserAsyncIsCalled()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminDeleteUserAsync(It.IsAny<AdminDeleteUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminDeleteUserResponse())).Verifiable();
+            await _store.DeleteAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenAddToRole_ThenAdminAddUserToGroupAsyncIsCalled()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminAddUserToGroupAsync(It.IsAny<AdminAddUserToGroupRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminAddUserToGroupResponse())).Verifiable();
+            await _store.AddToRoleAsync(_userMock.Object, "roleName", CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenRemoveFromRole_ThenAdminRemoveUserFromGroupAsyncIsCalled()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminRemoveUserFromGroupAsync(It.IsAny<AdminRemoveUserFromGroupRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminRemoveUserFromGroupResponse())).Verifiable();
+            await _store.RemoveFromRoleAsync(_userMock.Object, "roleName", CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetRoles_ThenTheUserRolesAreRetrieved()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminListGroupsForUserAsync(It.IsAny<AdminListGroupsForUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(LIST_GROUPS_FOR_USERS_RESPONSE)).Verifiable();
+            var output = await _store.GetRolesAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(LIST_GROUPS_FOR_USERS_RESPONSE.Groups.Count, output.Count);
+            Assert.Equal(LIST_GROUPS_FOR_USERS_RESPONSE.Groups[0].GroupName, output[0]);
+            Assert.Equal(LIST_GROUPS_FOR_USERS_RESPONSE.Groups[1].GroupName, output[1]);
+            Assert.Equal(LIST_GROUPS_FOR_USERS_RESPONSE.Groups[2].GroupName, output[2]);
+            _cognitoClientMock.Verify();
+        }
+
+        [Theory]
+        [InlineData("group1", true)]
+        [InlineData("unknownGroup", false)]
+        public async void Test_GivenAUserAndARoleName_WhenIsInRole_ThenTheResponseIsValid(string roleName, bool isInRole)
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminListGroupsForUserAsync(It.IsAny<AdminListGroupsForUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(LIST_GROUPS_FOR_USERS_RESPONSE)).Verifiable();
+            var output = await _store.IsInRoleAsync(_userMock.Object, roleName, CancellationToken.None).ConfigureAwait(false);
+            Assert.Equal(isInRole, output);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetNormalizedUserName_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.GetNormalizedUserNameAsync(_userMock.Object, CancellationToken.None)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenSetNormalizedUserName_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.SetNormalizedUserNameAsync(_userMock.Object, "userName", CancellationToken.None)).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenSetSetUserName_ThenThrowsANotSupportedException()
+        {
+            await Assert.ThrowsAsync<NotSupportedException>(() => _store.SetUserNameAsync(_userMock.Object, "userName", CancellationToken.None)).ConfigureAwait(false);
+        }
+    }
+}

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserTwoFactorStoreTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserStore.IUserTwoFactorStoreTest.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * 
+ *  http://aws.amazon.com/apache2.0
+ * 
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+using Amazon.CognitoIdentityProvider.Model;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Amazon.AspNetCore.Identity.Cognito.Test
+{
+    public partial class CognitoUserStoreTest
+    {
+        [Fact]
+        public async void Test_GivenAUser_WhenGetTwoFactorEnabledWithAnMFAOption_ThenTheResponseIsTrue()
+        {
+            var response = new AdminGetUserResponse()
+            {
+                MFAOptions = new List<MFAOptionType>()
+                {
+                    new MFAOptionType()
+                }
+            };
+            _cognitoClientMock.Setup(mock => mock.AdminGetUserAsync(It.IsAny<AdminGetUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response)).Verifiable();
+            var output = await _store.GetTwoFactorEnabledAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.True(output);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenGetTwoFactorEnabledWithoutAnMFAOption_ThenTheResponseIsFalse()
+        {
+            var response = new AdminGetUserResponse()
+            {
+                MFAOptions = new List<MFAOptionType>()
+            };
+            _cognitoClientMock.Setup(mock => mock.AdminGetUserAsync(It.IsAny<AdminGetUserRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(response)).Verifiable();
+            var output = await _store.GetTwoFactorEnabledAsync(_userMock.Object, CancellationToken.None).ConfigureAwait(false);
+            Assert.False(output);
+            _cognitoClientMock.Verify();
+        }
+
+        [Fact]
+        public async void Test_GivenAUser_WhenSetTwoFactorEnabled_ThenAdminSetUserSettingsAsyncIsCalled()
+        {
+            _cognitoClientMock.Setup(mock => mock.AdminSetUserSettingsAsync(It.IsAny<AdminSetUserSettingsRequest>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(new AdminSetUserSettingsResponse())).Verifiable();
+            await _store.SetTwoFactorEnabledAsync(_userMock.Object, false, CancellationToken.None).ConfigureAwait(false);
+            _cognitoClientMock.Verify();
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3261

*Description of changes:*
Various stores unit test coverage.
Some methods could not be unit tested due to non-virtual methods in some dependencies. They will get integ test coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
