### PR TITLE
GetUsersForClaimAsync implementation for the filterable attributes

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoAttributesConstants.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoAttributesConstants.cs
@@ -25,6 +25,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public const string BirthDate = "birthdate";
         public const string Email = "email";
         public const string EmailVerified = "email_verified";
+        public const string Enabled = "status";
         public const string FamilyName = "family_name";
         public const string Gender = "gender";
         public const string GivenName = "given_name";
@@ -37,8 +38,15 @@ namespace Amazon.AspNetCore.Identity.Cognito
         public const string Picture = "picture";
         public const string PreferredUsername = "preferred_username";
         public const string Profile = "profile";
-        public const string ZoneInfo = "zoneinfo";
+        public const string Sub = "sub";
         public const string UpdatedAt = "updated_at";
+        public const string UserName = "username ";
+        public const string UserStatus = "cognito:user_status";
         public const string Website = "website";
+        public const string ZoneInfo = "zoneinfo";
+
+        // List of attributes filterable through the ListUsers API.
+        public static readonly string[] FilterableAttributes = { Email, Enabled, GivenName,
+            FamilyName, PhoneNumber, PreferredUsername, Name, Sub, UserName, UserStatus };
     }
 }


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3275

*Description of changes:* Right now retrieving the list of users for a specific claim is not supported, as the Cognito API ListUsers only support a few fields for filtering. 

A customer recently requested to support these fields. See comments here: https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/41


This change adds the support, and throws an exception when filtering with a non supported field. 
See: https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUsers.html

Another change would be to let the api call fail altogether when providing a non supported field, but this may be surprising to developers, so I figured out than throwing a proper exception is nice. But we have to maintain the code when all the attributes will be supported by Cognito. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
