### PR TITLE
Resend a user signup confirmation code

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -351,6 +351,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
 
         /// <summary>
         /// Confirms the email of an user by validating that an email confirmation token is valid for the specified <paramref name="user"/>.
+        /// This operation requires a logged in user.
         /// </summary>
         /// <param name="user">The user to validate the token against.</param>
         /// <param name="confirmationCode">The email confirmation code to validate.</param>
@@ -367,6 +368,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
 
         /// <summary>
         /// Confirms the phone number of an user by validating that an email confirmation token is valid for the specified <paramref name="user"/>.
+        /// This operation requires a logged in user.
         /// </summary>
         /// <param name="user">The user to validate the token against.</param>
         /// <param name="confirmationCode">The phone number confirmation code to validate.</param>
@@ -431,6 +433,26 @@ namespace Amazon.AspNetCore.Identity.Cognito
                 throw new ArgumentNullException(nameof(user));
             }
             return _userStore.AdminConfirmSignUpAsync(user, CancellationToken);
+        }
+
+        /// <summary>
+        /// Resends the account signup confirmation code for the specified <paramref name="user"/>
+        /// as an asynchronous operation.
+        /// </summary>
+        /// <param name="user">The user to resend the account signup confirmation code for.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
+        /// of the operation.
+        /// </returns>
+        public virtual Task<IdentityResult> ResendSignupConfirmationCodeAsync(TUser user)
+        {
+            ThrowIfDisposed();
+
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+            return _userStore.ResendSignupConfirmationCodeAsync(user, CancellationToken);
         }
 
         /// <summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -314,9 +314,34 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         /// <summary>
+        /// Resends the account signup confirmation code for the specified <paramref name="user"/>
+        /// as an asynchronous operation.
+        /// </summary>
+        /// <param name="user">The user to resend the account signup confirmation code for.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
+        /// of the operation.
+        /// </returns>
+        public virtual async Task<IdentityResult> ResendSignupConfirmationCodeAsync(TUser user, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await user.ResendConfirmationCodeAsync().ConfigureAwait(false);
+                return IdentityResult.Success;
+            }
+            catch (AmazonCognitoIdentityProviderException e)
+            {
+                return IdentityResult.Failed(_errorDescribers.CognitoServiceError("Failed to resend the Cognito User signup confirmation code", e));
+            }
+        }
+
+        /// <summary>
         /// Generates and sends a verification code for the specified <paramref name="user"/>, 
         /// and the specified <paramref name="attributeName"/>,
         /// as an asynchronous operation.
+        /// This operation requires a logged in user.
         /// </summary>
         /// <param name="user">The user to send the verification code to.</param>
         /// <param name="attributeName">The attribute to verify.</param>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/IUserCognitoStore.cs
@@ -138,9 +138,21 @@ namespace Amazon.AspNetCore.Identity.Cognito
         Task<IdentityResult> AdminConfirmSignUpAsync(TUser user, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Resends the account signup confirmation code for the specified <paramref name="user"/>
+        /// as an asynchronous operation.
+        /// </summary>
+        /// <param name="user">The user to resend the account signup confirmation code for.</param>
+        /// <returns>
+        /// The <see cref="Task"/> that represents the asynchronous operation, containing the <see cref="IdentityResult"/>
+        /// of the operation.
+        /// </returns>
+        Task<IdentityResult> ResendSignupConfirmationCodeAsync(TUser user, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Generates and sends a verification code for the specified <paramref name="user"/>, 
         /// and the specified <paramref name="attributeName"/>,
         /// as an asynchronous operation.
+        /// This operation requires a logged in user.
         /// </summary>
         /// <param name="user">The user to send the verification code to.</param>
         /// <param name="attributeName">The attribute to verify.</param>

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
@@ -164,6 +164,15 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
         }
 
         [Fact]
+        public async void Test_GivenAUser_WhenResendSignupConfirmationCode_ThenResponseIsNotAltered()
+        {
+            userStoreMock.Setup(mock => mock.ResendSignupConfirmationCodeAsync(It.IsAny<CognitoUser>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(IdentityResult.Success)).Verifiable();
+            var output = await userManager.ResendSignupConfirmationCodeAsync(GetCognitoUser()).ConfigureAwait(false);
+            Assert.Equal(IdentityResult.Success, output);
+            userStoreMock.Verify();
+        }
+
+        [Fact]
         public async void Test_GivenAUser_WhenSetPhoneNumber_ThenResponseIsNotAltered()
         {
             userStoreMock.Setup(mock => mock.SetPhoneNumberAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(0)).Verifiable();


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3277

*Description of changes:* Exposes an api to Resend a user signup confirmation code as it is different from confirming an email. See https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/53 for background

Added a unit test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
