### PR TITLE
Make tokens also accessible through the http context.

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.6" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -129,7 +129,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>The task object representing the asynchronous operation.</returns>
         public override Task SignInAsync(TUser user, bool isPersistent, string authenticationMethod = null)
         {
-            // Populating the tokens to be retrieve when calling Context.GetTokenAsync(OpenIdConnectParameterNames.AccessToken).
+            // Populating the tokens to be retrieved when calling Context.GetTokenAsync(OpenIdConnectParameterNames.AccessToken).
             var authenticationProperties = new AuthenticationProperties
             {
                 IsPersistent = isPersistent,

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -339,7 +339,6 @@ namespace Amazon.AspNetCore.Identity.Cognito
         private async Task<TwoFactorAuthenticationInfo> RetrieveTwoFactorInfoAsync()
         {
             var result = await Context.AuthenticateAsync(IdentityConstants.TwoFactorUserIdScheme).ConfigureAwait(false);
-
             if (result?.Principal != null)
             {
                 return new TwoFactorAuthenticationInfo


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3286

*Description of changes:* In addition to the tokens accessible through the CognitoUser object, this codes adds them to the Context object.
This is useful to retrieve the AccessToken in another page for example, if the developer directly wants to call Cognito using this.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
