### PR TITLE
Populate session tokens when available through the context

### DIFF
--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoSigninManagerTest.cs
@@ -32,7 +32,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
 
         public CognitoSigninManagerTest() : base()
         {
-            userManagerMock = new Mock<CognitoUserManager<CognitoUser>>(userStoreMock.Object, null, null, null, null, null, null, null, null);
+            userManagerMock = new Mock<CognitoUserManager<CognitoUser>>(userStoreMock.Object, null, null, null, null, null, null, null, null, contextAccessorMock.Object);
             claimsFactoryMock = new Mock<CognitoUserClaimsPrincipalFactory<CognitoUser>>(userManagerMock.Object, optionsAccessorMock.Object);
             signinManager = new CognitoSignInManager<CognitoUser>(userManagerMock.Object, contextAccessorMock.Object, claimsFactoryMock.Object, optionsAccessorMock.Object, loggerSigninManagerMock.Object, schemesMock.Object);
         }

--- a/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
+++ b/test/Amazon.AspNetCore.Identity.Cognito.Test/CognitoUserManagerTest.cs
@@ -40,7 +40,8 @@ namespace Amazon.AspNetCore.Identity.Cognito.Test
                 keyNormalizer, 
                 errorsMock.Object, 
                 servicesMock.Object, 
-                loggerUserManagerMock.Object);
+                loggerUserManagerMock.Object,
+                contextAccessorMock.Object);
         }
 
         [Fact]


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3300

*Description of changes:* When switching pages, customers want to get the session tokens populated if they retrieve a user instance and this is the one currently logged in.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
