### PR TITLE
Disable security stamp validation as it is not supported by Cognito

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
-    <Version>0.9.0.8</Version>
+    <Version>0.9.0.9</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.AspNetCore.Identity.Cognito</PackageId>
     <Title>ASP.NET Core Identity Provider for Amazon Cognito</Title>
@@ -18,8 +18,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>0.9.0.8</AssemblyVersion>
-    <FileVersion>0.9.0.8</FileVersion>
+    <AssemblyVersion>0.9.0.9</AssemblyVersion>
+    <FileVersion>0.9.0.9</FileVersion>
   </PropertyGroup>
 
     <Choose>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -362,5 +362,19 @@ namespace Amazon.AspNetCore.Identity.Cognito
         }
 
         #endregion
+
+        /// <summary>
+        /// Validates the security stamp for the specified <paramref name="user"/>. Will always return false
+        /// if the userManager does not support security stamps.
+        /// </summary>
+        /// <param name="user">The user whose stamp should be validated.</param>
+        /// <param name="securityStamp">The expected security stamp value.</param>
+        /// <returns>True if the stamp matches the persisted value, otherwise it will return false.</returns>
+        public override async Task<bool> ValidateSecurityStampAsync(TUser user, string securityStamp)
+            => user != null &&
+            // Only validate the security stamp if the store supports it
+            (!UserManager.SupportsUserSecurityStamp || securityStamp == await UserManager.GetSecurityStampAsync(user).ConfigureAwait(false));
+        // Preventing the cookies from expiring every 30 minutes. This fix was only added to Identity 2.2.
+        // https://github.com/aspnet/Identity/pull/1941
     }
 }


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3287

*Description of changes:* There is a bug on Identity 2.1.6 which was fixed only on 2.2. This change applies the patch to our CognitoUserManager. 

The bug is making cookies force-expire every 30 minutes.

Additional change: when the cookie is expired, we don't populate the tokens.

Fixes https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/50

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
