### PR TITLE
Updating the sample app to include change and reset password examples

### DIFF
--- a/samples/Samples/Areas/Identity/Pages/Account/ChangePassword.cshtml
+++ b/samples/Samples/Areas/Identity/Pages/Account/ChangePassword.cshtml
@@ -1,0 +1,42 @@
+﻿@page
+@model ChangePasswordModel
+@{
+    ViewData["Title"] = "Change password";
+}
+
+<h2>@ViewData["Title"]</h2>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-route-returnUrl="@Model.ReturnUrl" method="post">
+            <h4>Change your password.</h4>
+            <hr />
+            <div asp-validation-summary="All" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Input.Email"></label>
+                <input asp-for="Input.Email" class="form-control" />
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.CurrentPassword"></label>
+                <input asp-for="Input.CurrentPassword" class="form-control" />
+                <span asp-validation-for="Input.CurrentPassword" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.NewPassword"></label>
+                <input asp-for="Input.NewPassword" class="form-control" />
+                <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.ConfirmPassword"></label>
+                <input asp-for="Input.ConfirmPassword" class="form-control" />
+                <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-default">Change your password</button>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/samples/Samples/Areas/Identity/Pages/Account/ChangePassword.cshtml.cs
+++ b/samples/Samples/Areas/Identity/Pages/Account/ChangePassword.cshtml.cs
@@ -1,0 +1,93 @@
+﻿using Amazon.AspNetCore.Identity.Cognito;
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+namespace Samples.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class ChangePasswordModel : PageModel
+    {
+        private readonly CognitoUserManager<CognitoUser> _userManager;
+        private readonly ILogger<LoginWith2faModel> _logger;
+
+        public ChangePasswordModel(UserManager<CognitoUser> userManger, ILogger<LoginWith2faModel> logger)
+        {
+            _userManager = userManger as CognitoUserManager<CognitoUser>;
+            _logger = logger;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; }
+
+        public string ReturnUrl { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            [Display(Name = "Email")]
+            public string Email { get; set; }
+
+            [Required]
+            [DataType(DataType.Password)]
+            [Display(Name = "Current password")]
+            public string CurrentPassword { get; set; }
+
+            [Required]
+            [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+            [DataType(DataType.Password)]
+            [Display(Name = "New password")]
+            public string NewPassword { get; set; }
+
+            [DataType(DataType.Password)]
+            [Display(Name = "Confirm password")]
+            [Compare("NewPassword", ErrorMessage = "The password and confirmation password do not match.")]
+            public string ConfirmPassword { get; set; }
+        }
+
+        public void OnGet(string returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+        }
+
+        public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            returnUrl = returnUrl ?? Url.Content("~/");
+
+            var user = await _userManager.FindByEmailAsync(Input.Email);
+            if (user == null)
+            {
+                throw new InvalidOperationException($"Unable to retrieve user.");
+            }
+
+            var result = await _userManager.ChangePasswordAsync(user, Input.CurrentPassword, Input.NewPassword);
+
+            if (result.Succeeded)
+            {
+                _logger.LogInformation("Changed password for user with ID '{UserId}'.", user.UserID);
+                return LocalRedirect(returnUrl);
+            }
+            else
+            {
+                _logger.LogInformation("Unable to change password for user with ID '{UserId}'.", user.UserID);
+                foreach (var item in result.Errors)
+                {
+                    ModelState.AddModelError(item.Code, item.Description);
+                }
+                return Page();
+            }
+        }
+    }
+}

--- a/samples/Samples/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/samples/Samples/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -83,11 +83,19 @@ namespace Samples.Areas.Identity.Pages.Account
                 }
                 else if (result.IsCognitoSignInResult())
                 {
-                    if (result is CognitoSignInResult cognitoResult && cognitoResult.RequiresPasswordChange)
+                    if (result is CognitoSignInResult cognitoResult)
                     {
-                        _logger.LogWarning("User password needs to be changed");
-                        return RedirectToPage("./ChangePassword");
-                    }
+                        if (cognitoResult.RequiresPasswordChange)
+                        {
+                            _logger.LogWarning("User password needs to be changed");
+                            return RedirectToPage("./ChangePassword");
+                        }
+                        else if (cognitoResult.RequiresPasswordReset)
+                        {
+                            _logger.LogWarning("User password needs to be reset");
+                            return RedirectToPage("./ResetPassword");
+                        }
+                    } 
 
                 }
 

--- a/samples/Samples/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/samples/Samples/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -69,7 +69,7 @@ namespace Samples.Areas.Identity.Pages.Account
             if (ModelState.IsValid)
             {
                 var user = _pool.GetUser(Input.UserName);
-                user.Attributes.Add(CognitoAttributesConstants.Email, Input.Email);
+                user.Attributes.Add(CognitoAttribute.Email.AttributeName, Input.Email);
 
                 var result = await _userManager.CreateAsync(user, Input.Password);
                 if (result.Succeeded)

--- a/samples/Samples/Areas/Identity/Pages/Account/ResetPassword.cshtml
+++ b/samples/Samples/Areas/Identity/Pages/Account/ResetPassword.cshtml
@@ -1,0 +1,42 @@
+﻿@page
+@model ResetPasswordModel
+@{
+    ViewData["Title"] = "Reset password";
+}
+
+<h2>@ViewData["Title"]</h2>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-route-returnUrl="@Model.ReturnUrl" method="post">
+            <h4>Reset your password.</h4>
+            <hr />
+            <div asp-validation-summary="All" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Input.Email"></label>
+                <input asp-for="Input.Email" class="form-control" />
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.ResetToken"></label>
+                <input asp-for="Input.ResetToken" class="form-control" />
+                <span asp-validation-for="Input.ResetToken" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.NewPassword"></label>
+                <input asp-for="Input.NewPassword" class="form-control" />
+                <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="Input.ConfirmPassword"></label>
+                <input asp-for="Input.ConfirmPassword" class="form-control" />
+                <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+            </div>
+            <button type="submit" class="btn btn-default">Reset your password</button>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/samples/Samples/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/samples/Samples/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -1,0 +1,93 @@
+﻿using Amazon.AspNetCore.Identity.Cognito;
+using Amazon.Extensions.CognitoAuthentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Threading.Tasks;
+
+namespace Samples.Areas.Identity.Pages.Account
+{
+    [AllowAnonymous]
+    public class ResetPasswordModel : PageModel
+    {
+        private readonly CognitoUserManager<CognitoUser> _userManager;
+        private readonly ILogger<LoginWith2faModel> _logger;
+
+        public ResetPasswordModel(UserManager<CognitoUser> userManger, ILogger<LoginWith2faModel> logger)
+        {
+            _userManager = userManger as CognitoUserManager<CognitoUser>;
+            _logger = logger;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; }
+
+        public string ReturnUrl { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            [Display(Name = "Email")]
+            public string Email { get; set; }
+
+            [Required]
+            [DataType(DataType.Text)]
+            [Display(Name = "Reset Token")]
+            public string ResetToken { get; set; }
+
+            [Required]
+            [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+            [DataType(DataType.Password)]
+            [Display(Name = "New password")]
+            public string NewPassword { get; set; }
+
+            [DataType(DataType.Password)]
+            [Display(Name = "Confirm password")]
+            [Compare("NewPassword", ErrorMessage = "The password and confirmation password do not match.")]
+            public string ConfirmPassword { get; set; }
+        }
+
+        public void OnGet(string returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+        }
+
+        public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            returnUrl = returnUrl ?? Url.Content("~/");
+
+            var user = await _userManager.FindByEmailAsync(Input.Email);
+            if (user == null)
+            {
+                throw new InvalidOperationException($"Unable to retrieve user.");
+            }
+
+            var result = await _userManager.ResetPasswordAsync(user, Input.ResetToken, Input.NewPassword);
+
+            if (result.Succeeded)
+            {
+                _logger.LogInformation("Password reset for user with ID '{UserId}'.", user.UserID);
+                return LocalRedirect(returnUrl);
+            }
+            else
+            {
+                _logger.LogInformation("Unable to rest password for user with ID '{UserId}'.", user.UserID);
+                foreach (var item in result.Errors)
+                {
+                    ModelState.AddModelError(item.Code, item.Description);
+                }
+                return Page();
+            }
+        }
+    }
+}

--- a/samples/Samples/Samples.csproj
+++ b/samples/Samples/Samples.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.AspNetCore.Identity.Cognito" Version="0.9.0.2" />
+    <PackageReference Include="Amazon.AspNetCore.Identity.Cognito" Version="0.9.0.11" />
     <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.1" PrivateAssets="All" />


### PR DESCRIPTION
*Issue #, if available:* DOTNET-3085

*Description of changes:* In order to provide scaffolded NuGet controllers, this changes updates the sample app with the latest version of the library as well as a change password and reset password example.

Fixes https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/35



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
