### PR TITLE
Multi targeting for ASP.NET Core 3.0 and backwards incompatible changes

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -1,7 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
     <Version>1.0.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -22,26 +21,26 @@
     <FileVersion>1.0.2</FileVersion>
   </PropertyGroup>
 
-    <Choose>
-    <When Condition=" '$(AWSKeyFile)' == '' ">
-      <PropertyGroup>
-        <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <AssemblyOriginatorKeyFile>$(AWSKeyFile)</AssemblyOriginatorKeyFile>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <DefineConstants>NETSTANDARD_2_0</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+      <DefineConstants>NETCOREAPP_3_0</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="1.0.3" />
     <PackageReference Include="AWSSDK.CognitoIdentity" Version="[3.3.100, 3.4)" />
     <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="[3.3.100, 3.4)" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="[3.3.100.1, 3.4)" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
 
@@ -57,4 +56,17 @@
   <ItemGroup>
     <None Include="../../LICENSE" Pack="true" PackagePath="" />
   </ItemGroup>
+
+  <Choose>
+    <When Condition=" '$(AWSKeyFile)' == '' ">
+      <PropertyGroup>
+        <AssemblyOriginatorKeyFile>..\..\public.snk</AssemblyOriginatorKeyFile>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <AssemblyOriginatorKeyFile>$(AWSKeyFile)</AssemblyOriginatorKeyFile>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 </Project>

--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -17,8 +17,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>1.0.2</AssemblyVersion>
-    <FileVersion>1.0.2</FileVersion>
+    <AssemblyVersion>1.0.3</AssemblyVersion>
+    <FileVersion>1.0.3</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoKeyNormalizer.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoKeyNormalizer.cs
@@ -18,12 +18,13 @@ using Microsoft.AspNetCore.Identity;
 namespace Amazon.AspNetCore.Identity.Cognito
 {
     /// <summary>
-    /// Implements ILookupNormalizer by returning the key without changes as Cogito is case sensitive.
+    /// Implements ILookupNormalizer by returning the key without changes as Cognito is case sensitive.
     /// For instance, a group named 'Test' is not the same as a group named 'test' in Cognito.
     /// The same is applicable to usernames.
     /// </summary>
     public class CognitoKeyNormalizer : ILookupNormalizer
     {
+#if NETSTANDARD_2_0
         /// <summary>
         /// Normalizes the key to be be used by Cognito.
         /// </summary>
@@ -34,5 +35,30 @@ namespace Amazon.AspNetCore.Identity.Cognito
             // Cognito does not handle normalization, returning the key as is.
             return key;
         }
+#endif
+
+#if NETCOREAPP_3_0
+        /// <summary>
+        /// Returns a normalized representation of the specified <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The key to normalize.</param>
+        /// <returns>A normalized representation of the specified <paramref name="name"/>.</returns>
+        public string NormalizeName(string name)
+        {
+            // Cognito does not handle normalization, returning the name as is.
+            return name;
+        }
+
+        /// <summary>
+        /// Returns a normalized representation of the specified <paramref name="email"/>.
+        /// </summary>
+        /// <param name="email">The email to normalize.</param>
+        /// <returns>A normalized representation of the specified <paramref name="email"/>.</returns>
+        public string NormalizeEmail(string email)
+        {
+            // Cognito does not handle normalization, returning the email as is.
+            return email;
+        }
+#endif
     }
 }

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoSigninManager.cs
@@ -37,12 +37,14 @@ namespace Amazon.AspNetCore.Identity.Cognito
         private const string Cognito2FAAuthWorkflowKey = "Cognito2FAAuthWorkflowId";
         private const string Cognito2FAProviderKey = "Amazon Cognito 2FA";
 
+#if NETCOREAPP_3_0
         public CognitoSignInManager(UserManager<TUser> userManager,
-            IHttpContextAccessor contextAccessor,
-            IUserClaimsPrincipalFactory<TUser> claimsFactory,
-            IOptions<IdentityOptions> optionsAccessor,
-            ILogger<SignInManager<TUser>> logger,
-            IAuthenticationSchemeProvider schemes) : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes)
+        IHttpContextAccessor contextAccessor,
+        IUserClaimsPrincipalFactory<TUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        ILogger<SignInManager<TUser>> logger,
+        IAuthenticationSchemeProvider schemes,
+        IUserConfirmation<TUser> confirmation) : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes, confirmation)
         {
 
             if (userManager == null)
@@ -62,6 +64,34 @@ namespace Amazon.AspNetCore.Identity.Cognito
 
             _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
         }
+#endif
+#if NETSTANDARD_2_0
+        public CognitoSignInManager(UserManager<TUser> userManager,
+        IHttpContextAccessor contextAccessor,
+        IUserClaimsPrincipalFactory<TUser> claimsFactory,
+        IOptions<IdentityOptions> optionsAccessor,
+        ILogger<SignInManager<TUser>> logger,
+        IAuthenticationSchemeProvider schemes) : base(userManager, contextAccessor, claimsFactory, optionsAccessor, logger, schemes)
+        {
+
+            if (userManager == null)
+                throw new ArgumentNullException(nameof(userManager));
+            if (claimsFactory == null)
+                throw new ArgumentNullException(nameof(claimsFactory));
+
+            if (userManager is CognitoUserManager<TUser>)
+                _userManager = userManager as CognitoUserManager<TUser>;
+            else
+                throw new ArgumentException("The userManager must be of type CognitoUserManager<TUser>", nameof(userManager));
+
+            if (claimsFactory is CognitoUserClaimsPrincipalFactory<TUser>)
+                _claimsFactory = claimsFactory as CognitoUserClaimsPrincipalFactory<TUser>;
+            else
+                throw new ArgumentException("The claimsFactory must be of type CognitoUserClaimsPrincipalFactory<TUser>", nameof(claimsFactory));
+
+            _contextAccessor = contextAccessor ?? throw new ArgumentNullException(nameof(contextAccessor));
+        }
+#endif
 
         /// <summary>
         /// Attempts to sign in the specified <paramref name="userId"/> and <paramref name="password"/> combination

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -73,8 +73,13 @@ namespace Amazon.AspNetCore.Identity.Cognito
             {
                 throw new ArgumentNullException(nameof(email));
             }
-
-            var user = await _userStore.FindByEmailAsync(NormalizeKey(email), CancellationToken).ConfigureAwait(false);
+#if NETCOREAPP_3_0
+            email = NormalizeEmail(email);
+#endif
+#if NETSTANDARD_2_0
+            email = NormalizeKey(email);
+#endif
+            var user = await _userStore.FindByEmailAsync(email, CancellationToken).ConfigureAwait(false);
             if (user != null)
             {
                 await PopulateTokens(user, ClaimTypes.Email, email).ConfigureAwait(false);
@@ -118,7 +123,12 @@ namespace Amazon.AspNetCore.Identity.Cognito
             {
                 throw new ArgumentNullException(nameof(userName));
             }
+#if NETCOREAPP_3_0
+            userName = NormalizeName(userName);
+#endif
+#if NETSTANDARD_2_0
             userName = NormalizeKey(userName);
+#endif
             var user = await _userStore.FindByNameAsync(userName, CancellationToken).ConfigureAwait(false);
             if (user != null)
             {


### PR DESCRIPTION
Fixes https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/103

*Description of changes:* Fixes exceptions when used from an asp .net core 3.0 app.

The exceptions come from the two following breaking changes:

https://github.com/aspnet/Announcements/issues/374
https://github.com/aspnet/AspNetCore/issues/8572

This is fixing the interface implementation and the SigninManager signature.

Tested with a 3.0 app.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
