### PR TITLE
Fixes an issue where a user pool with no password constraints requires symbols

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Extensions/CognitoServiceCollectionExtensions.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Extensions/CognitoServiceCollectionExtensions.cs
@@ -41,11 +41,24 @@ namespace Microsoft.Extensions.DependencyInjection
             if (identityOptions != null)
             {
                 services.Configure(identityOptions);
+                services.AddIdentity<CognitoUser, CognitoRole>()
+                    .AddDefaultTokenProviders()
+                    .AddPasswordValidator<CognitoPasswordValidator>();
             }
-
-            services.AddIdentity<CognitoUser, CognitoRole>()
-                .AddDefaultTokenProviders()
-                .AddPasswordValidator<CognitoPasswordValidator>();
+            else
+            {
+                services.AddIdentity<CognitoUser, CognitoRole>()
+                    .AddDefaultTokenProviders()
+                    .AddPasswordValidator<CognitoPasswordValidator>();
+                var passwordValidators = services.Where(s => s.ServiceType.Equals(typeof(IPasswordValidator<CognitoUser>)));
+                foreach (var validator in passwordValidators.ToArray())
+                {
+                    if (Equals(validator.ImplementationType, typeof(PasswordValidator<CognitoUser>)))
+                    {
+                        services.Remove(validator);
+                    }
+                }
+            }
 
             // Overrides the managers/stores with Cognito specific ones.
             services.AddScoped<UserManager<TUser>, CognitoUserManager<TUser>>();


### PR DESCRIPTION
https://github.com/aws/aws-aspnet-cognito-identity-provider/issues/133

Removes Microsoft password validator implementation that overrides the Cognito password validator

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.