### PR TITLE
Update AWS SDK package references upper bound to 4.0

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -38,9 +38,9 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="1.0.3" />
-    <PackageReference Include="AWSSDK.CognitoIdentity" Version="[3.3.100, 3.4)" />
-    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="[3.3.100, 3.4)" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="[3.3.100.1, 3.4)" />
+    <PackageReference Include="AWSSDK.CognitoIdentity" Version="[3.3.100, 4.0)" />
+    <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="[3.3.100, 4.0)" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="[3.3.100.1, 4.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
To allow usage of AWSSDKs with version less than equal to 4.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
