### PR TITLE
Issued ClaimsIdentity should use the name and role from IdentityOptions

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserClaimsPrincipalFactory.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserClaimsPrincipalFactory.cs
@@ -70,7 +70,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
             // Roles are claims with a specific schema uri
             roles.ToList().ForEach(role => claims.Add(new Claim(roleClaimType, role)));
 
-            var claimsIdentity = new ClaimsIdentity(claims, IdentityConstants.ApplicationScheme);
+            var claimsIdentity = new ClaimsIdentity(claims, IdentityConstants.ApplicationScheme, _identityOptions.ClaimsIdentity.UserNameClaimType, roleClaimType);
             return new ClaimsPrincipal(claimsIdentity);
         }
 


### PR DESCRIPTION


*Issue #, if available:* This may be correcting #163

*Description of changes:* 

I use differing claims types for role and name so they match up for what the oauth specification uses, via:

```
            services.Configure<IdentityOptions>(options =>
            {
                options.ClaimsIdentity.UserNameClaimType = Claims.Name;
                options.ClaimsIdentity.RoleClaimType = Claims.Role;
            });
```

Once I had made this change I noticed the issued `ClaimsIdentity` still had the default `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name` and `http://schemas.microsoft.com/ws/2008/06/identity/claims/role` claim types. This pull requests updates the issued `ClaimsIdentity` so it uses what is in `IdentityOptions`. Defaults are unchanged here.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
