### PR TITLE
Feature/add totp support

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.CognitoIdentityProvider;
 using Amazon.Extensions.CognitoAuthentication;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -197,7 +198,20 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="code">The 2fa code to check</param>
         /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
-        public virtual Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId)
+        public virtual Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync2(TUser user, string code, string authWorkflowSessionId)
+        {
+            return RespondToTwoFactorChallengeAsync(user, code, ChallengeNameType.SMS_MFA, authWorkflowSessionId);
+        }
+
+        /// <summary>
+        /// Checks if the <param name="user"> can log in with the specified 2fa code challenge <paramref name="code"/>.
+        /// </summary>
+        /// <param name="user">The user try to log in with.</param>
+        /// <param name="code">The 2fa code to check</param>
+        /// <param name="challengeNameType">The ongoing Cognito challenge name type.</param>
+        /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
+        public virtual Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, ChallengeNameType challengeNameType,  string authWorkflowSessionId)
         {
             ThrowIfDisposed();
             if (user == null)
@@ -205,7 +219,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
                 throw new ArgumentNullException(nameof(user));
             }
 
-            return _userStore.RespondToTwoFactorChallengeAsync(user, code, authWorkflowSessionId, CancellationToken);
+            return _userStore.RespondToTwoFactorChallengeAsync(user, code, challengeNameType, authWorkflowSessionId, CancellationToken);
         }
 
         /// <summary>

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserManager.cs
@@ -198,7 +198,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <param name="code">The 2fa code to check</param>
         /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
-        public virtual Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync2(TUser user, string code, string authWorkflowSessionId)
+        public virtual Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId)
         {
             return RespondToTwoFactorChallengeAsync(user, code, ChallengeNameType.SMS_MFA, authWorkflowSessionId);
         }

--- a/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/CognitoUserStore/CognitoUserStore.cs
@@ -39,7 +39,7 @@ namespace Amazon.AspNetCore.Identity.Cognito
         {
             _cognitoClient = cognitoClient ?? throw new ArgumentNullException(nameof(cognitoClient));
             _pool = pool ?? throw new ArgumentNullException(nameof(pool));
-            
+
             // IdentityErrorDescriber provides predefined error strings such as PasswordMismatch() or InvalidUserName(String)
             // This is used when returning an instance of IdentityResult, which can be constructed with an array of errors to be surfaced to the UI.
             if (errors == null)
@@ -88,15 +88,29 @@ namespace Amazon.AspNetCore.Identity.Cognito
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
         public virtual async Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, string authWorkflowSessionId, CancellationToken cancellationToken)
         {
+            return await RespondToTwoFactorChallengeAsync(user, code, ChallengeNameType.SMS_MFA, authWorkflowSessionId, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Checks if the <param name="user"> can log in with the specified 2fa code challenge <paramref name="code"/>.
+        /// </summary>
+        /// <param name="user">The user try to log in with.</param>
+        /// <param name="code">The 2fa code to check</param>
+        /// <param name="challengeNameType">The ongoing Cognito authentication challenge name type.</param>
+        /// <param name="authWorkflowSessionId">The ongoing Cognito authentication workflow id.</param>
+        /// <returns>The <see cref="Task"/> that represents the asynchronous operation, containing the AuthFlowResponse object linked to that authentication workflow.</returns>
+        public virtual async Task<AuthFlowResponse> RespondToTwoFactorChallengeAsync(TUser user, string code, ChallengeNameType challengeNameType, string authWorkflowSessionId, CancellationToken cancellationToken)
+        {
             cancellationToken.ThrowIfCancellationRequested();
 
             try
             {
                 AuthFlowResponse context =
-                    await user.RespondToSmsMfaAuthAsync(new RespondToSmsMfaRequest()
+                    await user.RespondToMfaAuthAsync(new RespondToMfaRequest()
                     {
                         SessionID = authWorkflowSessionId,
-                        MfaCode = code
+                        MfaCode = code,
+                        ChallengeNameType = challengeNameType
                     }).ConfigureAwait(false);
 
                 return context;

--- a/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/CognitoSigninManagerTests.cs
+++ b/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/CognitoSigninManagerTests.cs
@@ -147,7 +147,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Tests
             var authFlowResponse = new AuthFlowResponse("sessionId", null, ChallengeNameType.SMS_MFA, null, null);
 
             userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
-            userManagerMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>()))
+            userManagerMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<ChallengeNameType>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(authFlowResponse))
                 .Callback(() => cognitoUser.SessionTokens = new CognitoUserSession("idToken", "accessToken", "refreshToken", DateTime.Now, DateTime.Now.AddDays(1))).Verifiable();
             userManagerMock.Setup(mock => mock.GetClaimsAsync(It.IsAny<CognitoUser>())).Returns(Task.FromResult(new List<Claim>() as IList<Claim>)).Verifiable();
@@ -170,7 +170,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Tests
             AuthFlowResponse authFlowResponse = null;
 
             userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
-            userManagerMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>()))
+            userManagerMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<ChallengeNameType>(), It.IsAny<string>()))
                 .Returns(Task.FromResult(authFlowResponse)).Verifiable();
 
             var output = await signinManager.RespondToTwoFactorChallengeAsync("2FACODE", true, false).ConfigureAwait(false);

--- a/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/CognitoSigninManagerTests.cs
+++ b/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/CognitoSigninManagerTests.cs
@@ -144,7 +144,7 @@ namespace Amazon.AspNetCore.Identity.Cognito.Tests
             var context = MockUtils.MockContext(cognitoUser, IdentityConstants.TwoFactorUserIdScheme);
             contextAccessorMock.Setup(a => a.HttpContext).Returns(context).Verifiable();
 
-            var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
+            var authFlowResponse = new AuthFlowResponse("sessionId", null, ChallengeNameType.SMS_MFA, null, null);
 
             userManagerMock.Setup(mock => mock.FindByIdAsync(It.IsAny<string>())).Returns(Task.FromResult(cognitoUser)).Verifiable();
             userManagerMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>()))

--- a/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/CognitoUserManagerTests.cs
+++ b/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/CognitoUserManagerTests.cs
@@ -13,6 +13,7 @@
  * permissions and limitations under the License.
  */
 
+using Amazon.CognitoIdentityProvider;
 using Amazon.Extensions.CognitoAuthentication;
 using Microsoft.AspNetCore.Identity;
 using Moq;
@@ -57,8 +58,8 @@ namespace Amazon.AspNetCore.Identity.Cognito.Tests
         [Fact]
         public async void Test_GivenAUser_WhenRespondToTwoFactorChallenge_ThenResponseIsNotAltered()
         {
-            var authFlowResponse = new AuthFlowResponse("sessionId", null, null, null, null);
-            userStoreMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(authFlowResponse)).Verifiable();
+            var authFlowResponse = new AuthFlowResponse("sessionId", null, ChallengeNameType.SMS_MFA, null, null);
+            userStoreMock.Setup(mock => mock.RespondToTwoFactorChallengeAsync(It.IsAny<CognitoUser>(), It.IsAny<string>(), It.IsAny<ChallengeNameType>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(authFlowResponse)).Verifiable();
             var output = await userManager.RespondToTwoFactorChallengeAsync(GetCognitoUser(), "2FACODE", "SessionId").ConfigureAwait(false);
             Assert.Equal(authFlowResponse, output);
             userStoreMock.Verify();


### PR DESCRIPTION
#168 

*Description of changes:*
With the changes in the Amazon.Extensions.CognitoAuthentication which are on pull request https://github.com/aws/aws-sdk-net-extensions-cognito/pull/58, these changes will enable TOTP support alongside the existing SMS 2fa. Where I can I have tried to make the changes backwardly compatible.

Also there is a bug fixed in this in the CheckPasswordSignInAsync, where is creates a ClaimsIdentity for passing the 2fa claims over to the next request an authentication type must be set other wise the next call to Context.SignInAsync will fail as no identity will be in the current request and it throws an exception.

Just as a note, this will currently not build without the changes on https://github.com/aws/aws-sdk-net-extensions-cognito/pull/58

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
