### PR TITLE
Fixes an issue where Calling RefreshSignInAsync() causes InvalidParameterException (Missing required parameter REFRESH_TOKEN)

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.AspNetCore.Identity.Cognito</PackageId>
     <Title>ASP.NET Core Identity Provider for Amazon Cognito</Title>
@@ -17,8 +17,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="2.0.0" />
+    <PackageReference Include="Amazon.Extensions.CognitoAuthentication" Version="2.0.2" />
     <PackageReference Include="AWSSDK.CognitoIdentity" Version="3.5.1.8" />
     <PackageReference Include="AWSSDK.CognitoIdentityProvider" Version="3.5.1.6" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />


### PR DESCRIPTION
*Issue:* #144 

*Description of changes:*
Fixes an issue where Calling RefreshSignInAsync() causes InvalidParameterException (Missing required parameter REFRESH_TOKEN). Bumps up the version of `Amazon.Extensions.CognitoAuthentication` to `2.0.2` which has the fix.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
