### PR TITLE
Make AWS:UserPoolClientSecret configuration value optional.

### DIFF
--- a/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Amazon.AspNetCore.Identity.Cognito.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <CodeAnalysisRuleSet>../ruleset.xml</CodeAnalysisRuleSet>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Amazon.AspNetCore.Identity.Cognito</PackageId>
     <Title>ASP.NET Core Identity Provider for Amazon Cognito</Title>
@@ -17,8 +17,8 @@
     <RepositoryUrl>https://github.com/aws/aws-aspnet-cognito-identity-provider/</RepositoryUrl>
     <Company>Amazon Web Services</Company>
     <SignAssembly>true</SignAssembly>
-    <AssemblyVersion>2.0.2</AssemblyVersion>
-    <FileVersion>2.0.2</FileVersion>
+    <AssemblyVersion>2.0.3</AssemblyVersion>
+    <FileVersion>2.0.3</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Amazon.AspNetCore.Identity.Cognito/Extensions/ConfigurationExtensions.cs
+++ b/src/Amazon.AspNetCore.Identity.Cognito/Extensions/ConfigurationExtensions.cs
@@ -55,22 +55,20 @@ namespace Microsoft.Extensions.Configuration
                 return options;
 
             options.UserPoolClientId = GetConfigurationValue(section, ConfigurationClientIdKey);
-            options.UserPoolClientSecret = GetConfigurationValue(section, ConfigurationClientSecretKey);
+            options.UserPoolClientSecret = GetConfigurationValue(section, ConfigurationClientSecretKey, true);
             options.UserPoolId = GetConfigurationValue(section, ConfigurationUserPoolIdKey);
             
             return options;
         }
 
-        private static string GetConfigurationValue(IConfiguration section, string configurationKey)
+        private static string GetConfigurationValue(IConfiguration section, string configurationKey, bool isOptional = false)
         {
-            if (!string.IsNullOrEmpty(section[configurationKey]))
+            if (!string.IsNullOrEmpty(section[configurationKey]) || isOptional)
             {
                 return section[configurationKey];
             }
-            else
-            {
-                throw new CognitoConfigurationException(string.Format(MissingKeyExceptionMessage, configurationKey));
-            }
+
+            throw new CognitoConfigurationException(string.Format(MissingKeyExceptionMessage, configurationKey));
         }
     }
 }


### PR DESCRIPTION
**Issue**: #124

**Description of changes:**
Make AWS:UserPoolClientSecret configuration value optional.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
