### PR TITLE
ci: onboard the repo to the testing infra

### DIFF
--- a/.github/workflows/aws-ci.yml
+++ b/.github/workflows/aws-ci.yml
@@ -1,0 +1,46 @@
+name: AWS CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+      - dev
+      - 'feature/**'
+
+permissions:
+  id-token: write
+
+jobs:
+  run-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
+        with:
+          role-to-assume: ${{ secrets.CI_MAIN_TESTING_ACCOUNT_ROLE_ARN }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
+      - name: Invoke Load Balancer Lambda
+        id: lambda
+        shell: pwsh
+        run: |
+          aws lambda invoke response.json --function-name "${{ secrets.CI_TESTING_LOAD_BALANCER_LAMBDA_NAME }}" --cli-binary-format raw-in-base64-out --payload '{"Roles": "${{ secrets.CI_TEST_RUNNER_ACCOUNT_ROLES }}", "ProjectName": "${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}", "Branch": "${{ github.sha }}"}'
+          $roleArn=$(cat ./response.json)
+          "roleArn=$($roleArn -replace '"', '')" >> $env:GITHUB_OUTPUT
+      - name: Configure Test Runner Credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 #v4
+        with:
+          role-to-assume: ${{ steps.lambda.outputs.roleArn }}
+          role-duration-seconds: 7200
+          aws-region: us-west-2
+      - name: Run Tests on AWS
+        id: codebuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ secrets.CI_TESTING_CODE_BUILD_PROJECT_NAME }}
+      - name: CodeBuild Link
+        shell: pwsh
+        run: |
+          $buildId = "${{ steps.codebuild.outputs.aws-build-id }}"
+          echo $buildId

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -1,0 +1,15 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      dotnet: 8.x
+  build:
+    commands:
+      - dotnet test test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/Amazon.AspNetCore.Identity.Cognito.Tests.csproj -c Release --logger trx --results-directory ./testresults
+reports:
+    aws-ssm-data-protection-provider-for-aspnet-tests:
+        file-format: VisualStudioTrx
+        files:
+            - '**/*'
+        base-directory: './testresults'

--- a/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/Amazon.AspNetCore.Identity.Cognito.Tests.csproj
+++ b/test/unit/Amazon.AspNetCore.Identity.Cognito.Tests/Amazon.AspNetCore.Identity.Cognito.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>Major</RollForward>
     <ApplicationIcon />
     <StartupObject />
   </PropertyGroup>


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7751

*Description of changes:*
This PR onboards the GitHub repo to the `aws-tools-ci` testing infra.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
